### PR TITLE
Fix useInScope example

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,15 +267,16 @@ Resources can be allocated within a scope. They will be released in reverse acqu
 (that is, after all forks started within finish). E.g.:
 
 ```scala
-import ox.{supervised, useScoped}
+import ox.{supervised, useInScope}
 
 case class MyResource(c: Int)
 
-def acquire: MyResource = 
-  println("acquiring ...")
-  MyResource(5)
+def acquire(c: Int) : MyResource =
+  println(s"acquiring $c ...")
+  MyResource(c)
+
 def release(resource: MyResource): Unit =
-  println(s"releasing ${resource.c}...")
+  println(s"releasing ${resource.c} ...")
 
 supervised {
   val resource1 = useInScope(acquire(10))(release)


### PR DESCRIPTION
This change 
 - adds import of `useInScope` that was missing
 - clarifies what value resource is acquired for 

Output before the change

```
acquiring ...
acquiring ...
Using MyResource(10) ...
Using MyResource(20) ...
releasing 20 ...
releasing 10 ...
```

and after change 

```
acquiring 10 ...
acquiring 20 ...
Using MyResource(10) ...
Using MyResource(20) ...
releasing 20 ...
releasing 10 ...
```