### PR TITLE
Add Source.mapStateful and Source.mapStatefulConcat combinators

### DIFF
--- a/core/src/main/scala/ox/channels/SourceOps.scala
+++ b/core/src/main/scala/ox/channels/SourceOps.scala
@@ -246,9 +246,9 @@ trait SourceOps[+T] { this: Source[T] =>
 
   def applied[U](f: Source[T] => U): U = f(this)
 
-  /** Applies the given mapping function `f`, using additional mutable state, to each element received from this source, and sends the
-    * results to the returned channel. Optionally sends an additional element, possibly based on the final state, to the returned channel
-    * once this source is done.
+  /** Applies the given mapping function `f`, using additional state, to each element received from this source, and sends the results to
+    * the returned channel. Optionally sends an additional element, possibly based on the final state, to the returned channel once this
+    * source is done.
     *
     * The `initializeState` function is called once when `statefulMap` is called.
     *
@@ -288,9 +288,9 @@ trait SourceOps[+T] { this: Source[T] =>
 
     mapStatefulConcat(initializeState)(resultToSome, onComplete)
 
-  /** Applies the given mapping function `f`, using additional mutable state, to each element received from this source, and sends the
-    * results one by one to the returned channel. Optionally sends an additional element, possibly based on the final state, to the returned
-    * channel once this source is done.
+  /** Applies the given mapping function `f`, using additional state, to each element received from this source, and sends the results one
+    * by one to the returned channel. Optionally sends an additional element, possibly based on the final state, to the returned channel
+    * once this source is done.
     *
     * The `initializeState` function is called once when `statefulMap` is called.
     *

--- a/core/src/test/scala/ox/channels/SourceOpsMapStatefulConcatTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsMapStatefulConcatTest.scala
@@ -1,0 +1,79 @@
+package ox.channels
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.*
+
+class SourceOpsMapStatefulConcatTest extends AnyFlatSpec with Matchers {
+
+  behavior of "Source.mapStatefulConcat"
+
+  it should "deduplicate" in scoped {
+    // given
+    val c = Source.fromValues(1, 2, 2, 3, 2, 4, 3, 1, 5)
+
+    // when
+    val s = c.mapStatefulConcat(() => Set.empty[Int])((s, e) => (s + e, Option.unless(s.contains(e))(e)))
+
+    // then
+    s.toList shouldBe List(1, 2, 3, 4, 5)
+  }
+
+  it should "count consecutive" in scoped {
+    // given
+    val c = Source.fromValues("apple", "apple", "apple", "banana", "orange", "orange", "apple")
+
+    // when
+    val s = c.mapStatefulConcat(() => (Option.empty[String], 0))(
+      { case ((previous, count), e) =>
+        previous match
+          case None      => ((Some(e), 1), None)
+          case Some(`e`) => ((previous, count + 1), None)
+          case Some(_)   => ((Some(e), 1), previous.map((_, count)))
+      },
+      { case (previous, count) => previous.map((_, count)) }
+    )
+
+    // then
+    s.toList shouldBe List(
+      ("apple", 3),
+      ("banana", 1),
+      ("orange", 2),
+      ("apple", 1)
+    )
+  }
+
+  it should "propagate errors in the mapping function" in scoped {
+    // given
+    val c = Source.fromValues("a", "b", "c")
+
+    // when
+    val s = c.mapStatefulConcat(() => 0) { (index, element) =>
+      if (index < 2) (index + 1, Some(element))
+      else throw new RuntimeException("boom")
+    }
+
+    // then
+    s.receive() shouldBe "a"
+    s.receive() shouldBe "b"
+    s.receive() should matchPattern {
+      case ChannelClosed.Error(Some(reason)) if reason.getMessage == "boom" =>
+    }
+  }
+
+  it should "propagate errors in the completion callback" in scoped {
+    // given
+    val c = Source.fromValues("a", "b", "c")
+
+    // when
+    val s = c.mapStatefulConcat(() => 0)((index, element) => (index + 1, Some(element)), _ => throw new RuntimeException("boom"))
+
+    // then
+    s.receive() shouldBe "a"
+    s.receive() shouldBe "b"
+    s.receive() shouldBe "c"
+    s.receive() should matchPattern {
+      case ChannelClosed.Error(Some(reason)) if reason.getMessage == "boom" =>
+    }
+  }
+}

--- a/core/src/test/scala/ox/channels/SourceOpsMapStatefulTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsMapStatefulTest.scala
@@ -4,14 +4,14 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import ox.*
 
-class SourceOpsStatefulMapTest extends AnyFlatSpec with Matchers {
+class SourceOpsMapStatefulTest extends AnyFlatSpec with Matchers {
 
-  behavior of "Source.statefulMap"
+  behavior of "Source.mapStateful"
 
   it should "zip with index" in scoped {
     val c = Source.fromValues("a", "b", "c")
 
-    val s = c.statefulMap(() => 0)((index, element) => (index + 1, Some((element, index))))
+    val s = c.mapStateful(() => 0)((index, element) => (index + 1, (element, index)))
 
     s.toList shouldBe List(("a", 0), ("b", 1), ("c", 2))
   }
@@ -19,20 +19,9 @@ class SourceOpsStatefulMapTest extends AnyFlatSpec with Matchers {
   it should "calculate a running total" in scoped {
     val c = Source.fromValues(1, 2, 3, 4, 5)
 
-    val s = c.statefulMap(() => 0)((sum, element) => (sum + element, Some(sum)), Some.apply)
+    val s = c.mapStateful(() => 0)((sum, element) => (sum + element, sum), Some.apply)
 
     s.toList shouldBe List(0, 1, 3, 6, 10, 15)
-  }
-
-  it should "deduplicate" in scoped {
-    val c = Source.fromValues(1, 2, 2, 3, 2, 4, 3, 1, 5)
-
-    val s = c.statefulMap(() => Set.empty[Int])((alreadySeen, element) =>
-      val result = Option.unless(alreadySeen.contains(element))(element)
-      (alreadySeen + element, result)
-    )
-
-    s.toList shouldBe List(1, 2, 3, 4, 5)
   }
 
   it should "propagate errors in the mapping function" in scoped {
@@ -40,8 +29,8 @@ class SourceOpsStatefulMapTest extends AnyFlatSpec with Matchers {
     val c = Source.fromValues("a", "b", "c")
 
     // when
-    val s = c.statefulMap(() => 0) { (index, element) =>
-      if (index < 2) (index + 1, Some(element))
+    val s = c.mapStateful(() => 0) { (index, element) =>
+      if (index < 2) (index + 1, element)
       else throw new RuntimeException("boom")
     }
 
@@ -58,7 +47,7 @@ class SourceOpsStatefulMapTest extends AnyFlatSpec with Matchers {
     val c = Source.fromValues("a", "b", "c")
 
     // when
-    val s = c.statefulMap(() => 0)((index, element) => (index + 1, Some(element)), _ => throw new RuntimeException("boom"))
+    val s = c.mapStateful(() => 0)((index, element) => (index + 1, element), _ => throw new RuntimeException("boom"))
 
     // then
     s.receive() shouldBe "a"

--- a/core/src/test/scala/ox/channels/SourceOpsStatefulMapTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsStatefulMapTest.scala
@@ -1,0 +1,37 @@
+package ox.channels
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.*
+
+class SourceOpsStatefulMapTest extends AnyFlatSpec with Matchers {
+
+  behavior of "Source.statefulMap"
+
+  it should "zip with index" in scoped {
+    val c = Source.fromValues("a", "b", "c")
+
+    val s = c.statefulMap(() => 0)((index, element) => (index + 1, Some((element, index))))
+
+    s.toList shouldBe List(("a", 0), ("b", 1), ("c", 2))
+  }
+
+  it should "calculate a running total" in scoped {
+    val c = Source.fromValues(1, 2, 3, 4, 5)
+
+    val s = c.statefulMap(() => 0)((sum, element) => (sum + element, Some(sum)), Some.apply)
+
+    s.toList shouldBe List(0, 1, 3, 6, 10, 15)
+  }
+
+  it should "deduplicate" in scoped {
+    val c = Source.fromValues(1, 2, 2, 3, 2, 4, 3, 1, 5)
+
+    val s = c.statefulMap(() => Set.empty[Int])((alreadySeen, element) =>
+      val result = Option.unless(alreadySeen.contains(element))(element)
+      (alreadySeen + element, result)
+    )
+
+    s.toList shouldBe List(1, 2, 3, 4, 5)
+  }
+}


### PR DESCRIPTION
I'm not sure whether `f` should return `(S, Option[U])` or `(S, U)` - where in the former case the `Option` indicates whether anything should be sent downstream. 

The former is more flexible, but introduces additional complexity to the signature. Comparing to Akka Streams, the current approach mixes `statefulMap` and `statefulMapConcat` a bit, in that you can control whether the result of `f` will be sent downstream at all. However, unlike in Akka Streams, `f` can only return an `Option`, not an `Iterable` (which is flattened in Akka's `statefulMapConcat`).

Any thoughts on this (or anything else in the proposed approach)?