### PR TITLE
feat: implement `drop` function

### DIFF
--- a/core/src/main/scala/ox/channels/SourceOps.scala
+++ b/core/src/main/scala/ox/channels/SourceOps.scala
@@ -2,7 +2,7 @@ package ox.channels
 
 import ox.*
 
-import java.util.concurrent.{ArrayBlockingQueue, ConcurrentLinkedQueue, CountDownLatch, LinkedBlockingQueue, Semaphore}
+import java.util.concurrent.{CountDownLatch, Semaphore}
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
 
@@ -140,6 +140,24 @@ trait SourceOps[+T] { this: Source[T] =>
     c
 
   def take(n: Int)(using Ox, StageCapacity): Source[T] = transform(_.take(n))
+
+  /** Drops `n` elements from this source and forwards subsequent elements to the returned channel.
+    *
+    * @param n
+    *   Number of elements to be dropped.
+    * @example
+    *   {{{
+    *   import ox.*
+    *   import ox.channels.Source
+    *
+    *   scoped {
+    *     Source.empty[Int].drop(1).toList          // List()
+    *     Source.fromValues(1, 2, 3).drop(1).toList // List(2 ,3)
+    *     Source.fromValues(1).drop(2).toList       // List()
+    *   }
+    *   }}}
+    */
+  def drop(n: Int)(using Ox, StageCapacity): Source[T] = transform(_.drop(n))
 
   def filter(f: T => Boolean)(using Ox, StageCapacity): Source[T] = transform(_.filter(f))
 

--- a/core/src/test/scala/ox/channels/SourceOpsDropTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsDropTest.scala
@@ -1,0 +1,29 @@
+package ox.channels
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.*
+
+class SourceOpsDropTest extends AnyFlatSpec with Matchers {
+  behavior of "Source.drop"
+
+  it should "not drop from the empty source" in supervised {
+    val s = Source.empty[Int]
+    s.drop(1).toList shouldBe List.empty
+  }
+
+  it should "drop elements from the source" in supervised {
+    val s = Source.fromValues(1, 2, 3)
+    s.drop(2).toList shouldBe List(3)
+  }
+
+  it should "return empty source when more elements than source length was dropped" in supervised {
+    val s = Source.fromValues(1, 2)
+    s.drop(3).toList shouldBe List.empty
+  }
+
+  it should "not drop when 'n == 0'" in supervised {
+    val s = Source.fromValues(1, 2, 3)
+    s.drop(0).toList shouldBe List(1, 2, 3)
+  }
+}


### PR DESCRIPTION
Drop `n` elements from the source and emit subsequent elements (if any left) e.g.:

```scala
  Source.empty[Int].drop(1).toList          // List()
  Source.fromValues(1, 2, 3).drop(1).toList // List(2 ,3)
  Source.fromValues(1).drop(2).toList       // List()
```