### PR TITLE
Don't rethrow exceptions in mapParUnordered

### DIFF
--- a/core/src/main/scala/ox/channels/SourceOps.scala
+++ b/core/src/main/scala/ox/channels/SourceOps.scala
@@ -188,8 +188,7 @@ trait SourceOps[+T] { this: Source[T] =>
                 try
                   c.send(f(t))
                   s.release()
-                catch
-                  case t: Throwable => c.error(t)
+                catch case t: Throwable => c.error(t)
               }
               true
         }
@@ -729,3 +728,15 @@ trait SourceCompanionOps:
           }
         }
         c
+
+  /** Creates a source that fails immediately with the given {{java.lang.Throwable}}
+    *
+    * @param t
+    *   the {{java.lang.Throwable}} to fail with
+    * @return
+    *   the failing source
+    */
+  def failed[T](t: Throwable): Source[T] =
+    val c = DirectChannel[T]()
+    c.error(t)
+    c

--- a/core/src/main/scala/ox/channels/SourceOps.scala
+++ b/core/src/main/scala/ox/channels/SourceOps.scala
@@ -729,12 +729,12 @@ trait SourceCompanionOps:
         }
         c
 
-  /** Creates a source that fails immediately with the given {{java.lang.Throwable}}
+  /** Creates a source that fails immediately with the given [[java.lang.Throwable]]
     *
     * @param t
-    *   the {{java.lang.Throwable}} to fail with
+    *   The [[java.lang.Throwable]] to fail with
     * @return
-    *   the failing source
+    *   A source that would fail immediately with the given [[java.lang.Throwable]]
     */
   def failed[T](t: Throwable): Source[T] =
     val c = DirectChannel[T]()

--- a/core/src/main/scala/ox/channels/SourceOps.scala
+++ b/core/src/main/scala/ox/channels/SourceOps.scala
@@ -182,16 +182,14 @@ trait SourceOps[+T] { this: Source[T] =>
             case ChannelClosed.Done => false
             case e @ ChannelClosed.Error(r) =>
               c.error(r)
-              throw e.toThrowable
+              false
             case t: T @unchecked =>
               fork {
                 try
                   c.send(f(t))
                   s.release()
                 catch
-                  case t: Throwable =>
-                    c.error(t)
-                    throw t
+                  case t: Throwable => c.error(t)
               }
               true
         }

--- a/core/src/test/scala/ox/channels/SourceOpsFailedTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsFailedTest.scala
@@ -1,0 +1,22 @@
+package ox.channels
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.*
+
+class SourceOpsFailedTest extends AnyFlatSpec with Matchers {
+
+  behavior of "Source.failed"
+
+  it should "fail on receive" in scoped {
+    // when
+    val s = Source.failed(RuntimeException("boom"))
+
+    // then  
+    s.receive() should matchPattern { case ChannelClosed.Error(Some(reason)) if reason.getMessage == "boom" => }
+  }
+
+  it should "be in error" in scoped {
+    Source.failed(RuntimeException("boom")).isError shouldBe true
+  }
+}

--- a/core/src/test/scala/ox/channels/SourceOpsMapParUnorderedTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsMapParUnorderedTest.scala
@@ -86,7 +86,7 @@ class SourceOpsMapParUnorderedTest extends AnyFlatSpec with Matchers with Eventu
         started.get() should be <= 7 // 4 successful + at most 3 taking up all the permits
   }
 
-  it should "complete running forks and not start new ones when there's an error" in scoped {
+  it should "complete running forks and not start new ones when the mapping function fails" in scoped {
     // given
     val trail = Trail()
     val s = Source.fromIterable(1 to 10)
@@ -114,6 +114,29 @@ class SourceOpsMapParUnorderedTest extends AnyFlatSpec with Matchers with Eventu
     // the fork that processes 4 would complete, thus adding "done" to the trail,
     // but it won't emit its result, since the channel would already be closed after the fork processing 3 failed
     trail.get shouldBe Vector("done", "done", "exception", "done")
+  }
+
+  it should "complete running forks and not start new ones when the upstream fails" in scoped {
+    // given
+    val trail = Trail()
+    val s = Source.fromValues(1, 2, 3).concat(Source.failed(new RuntimeException("boom")))
+
+    // when
+    val s2 = s.mapParUnordered(2) { i =>
+      Thread.sleep(100)
+      trail.add(i.toString)
+      i * 2
+    }
+
+    // then
+    List(s2.receive(), s2.receive()) should contain only (2, 4)
+    s2.receive() should matchPattern { case ChannelClosed.Error(Some(reason)) if reason.getMessage == "boom" => }
+    s2.isError shouldBe true
+
+    // checking if the forks aren't left running
+    Thread.sleep(200)
+
+    trail.get should contain only ("1", "2", "3")
   }
 
   it should "cancel running forks when the surrounding scope closes due to an error" in scoped {


### PR DESCRIPTION
Changes the error handling in `mapParUnordered` so that errors from upstream channel or from the mapping function are not rethrown, but only signalled to the downstream channel and used to terminate further processing. 

When the mapping function fails with an error, any already in-flight forks are allowed to complete, but their results are not sent downstream, since the downstream channel is closed immediately by the fork in error.

When the `receive()` from upstream fails, the downstream channel is closed and the internal loop terminates, so that no new forks are started.

Also adds `Source.failed(Throwable)` which was needed for one of the tests, so I decided not to put it in a separate PR.