### PR TITLE
feat: implement `throttle` function

### DIFF
--- a/core/src/test/scala/ox/channels/SourceOpsThrottleTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsThrottleTest.scala
@@ -1,0 +1,45 @@
+package ox.channels
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.*
+
+import scala.concurrent.duration.*
+
+class SourceOpsThrottleTest extends AnyFlatSpec with Matchers {
+  behavior of "Source.throttle"
+
+  it should "not throttle the empty source" in supervised {
+    val s = Source.empty[Int]
+    val (result, executionTime) = measure { s.throttle(1, 1.second).toList }
+    result shouldBe List.empty
+    executionTime.toMillis should be < 1.second.toMillis
+  }
+
+  it should "throttle to specified elements per time units" in supervised {
+    val s = Source.fromValues(1, 2)
+    val (result, executionTime) = measure { s.throttle(1, 50.millis).toList }
+    result shouldBe List(1, 2)
+    executionTime.toMillis should (be >= 100L and be <= 150L)
+  }
+
+  it should "fail to throttle when elements <= 0" in supervised {
+    val s = Source.empty[Int]
+    the[IllegalArgumentException] thrownBy {
+      s.throttle(-1, 50.millis)
+    } should have message "requirement failed: elements must be > 0"
+  }
+
+  it should "fail to throttle when per lower than 1ms" in supervised {
+    val s = Source.empty[Int]
+    the[IllegalArgumentException] thrownBy {
+      s.throttle(1, 50.nanos)
+    } should have message "requirement failed: per time must be >= 1 ms"
+  }
+
+  private def measure[T](f: => T): (T, Duration) =
+    val before = System.currentTimeMillis()
+    val result = f
+    val after = System.currentTimeMillis();
+    (result, (after - before).millis)
+}


### PR DESCRIPTION
Sends elements to the returned channel limiting the throughput to specific number of elements (evenly spaced) per time unit. Note that the element's `receive()` time is included in the resulting throughput. For instance having `throttle(1, 1.second)` and `receive()` taking `Xms` means that resulting channel will receive elements every `1s + Xms` time. Throttling is not applied to the empty source.

Examples:
```scala
  Source.empty[Int].throttle(1, 1.second).toList       // List() returned without throttling
  Source.fromValues(1, 2).throttle(1, 1.second).toList // List(1, 2) returned after 2 seconds
```

Note that implementation relies on `Thread.sleep` which is (according to [What is blocking Loom?](https://softwaremill.com/what-is-blocking-in-loom/) project Loom compatible.