### PR TITLE
feat: implement `Source.future` operator

### DIFF
--- a/core/src/test/scala/ox/channels/SourceOpsFutureTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsFutureTest.scala
@@ -1,0 +1,29 @@
+package ox.channels
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.*
+
+import scala.concurrent.Future
+
+class SourceOpsFutureTest extends AnyFlatSpec with Matchers {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  behavior of "Source.future"
+
+  it should "return the original future failure when future fails" in supervised {
+    val failure = new RuntimeException("future failed")
+    Source.future(Future.failed(failure)).receive() shouldBe ChannelClosed.Error(Some(failure))
+  }
+
+  it should "return the original future failure when future fails with ExecutionException" in supervised {
+    // according to https://docs.scala-lang.org/overviews/core/futures.html#exceptions
+    // the InterruptedException is one of the exceptions wrapped in ExecutionException
+    val failure = new InterruptedException("future interrupted")
+    Source.future(Future.failed(failure)).receive() shouldBe ChannelClosed.Error(Some(failure))
+  }
+
+  it should "return future value" in supervised {
+    Source.future(Future.successful(1)).toList shouldBe List(1)
+  }
+}


### PR DESCRIPTION
Creates a source that emits a single value when Future completes or fails otherwise.

Notes:
* when Future fails with `scala.concurrent.ExecutionException` then its cause is returned as source failure.
* the input Future cannot be `null`
* the `Future` completion is performed on the provided `ExecutionContext`

Examples:
```scala
  Source .future(Future.failed(new RuntimeException("future failed")))
    .receive()                               // ChannelClosed.Error(Some(java.lang.RuntimeException: future failed))
  Source.future(Future.successful(1)).toList // List(1)
```