### PR TITLE
feat: implement `Source.futureSource` operator

### DIFF
--- a/core/src/test/scala/ox/channels/SourceOpsFutureSourceTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsFutureSourceTest.scala
@@ -1,0 +1,29 @@
+package ox.channels
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.*
+
+import scala.concurrent.Future
+
+class SourceOpsFutureSourceTest extends AnyFlatSpec with Matchers {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  behavior of "SourceOps.futureSource"
+
+  it should "return the original future failure when future fails" in supervised {
+    val failure = new RuntimeException("future failed")
+    Source.futureSource(Future.failed(failure)).receive() shouldBe ChannelClosed.Error(Some(failure))
+  }
+
+  it should "return the original future failure when future fails with ExecutionException" in supervised {
+    // according to https://docs.scala-lang.org/overviews/core/futures.html#exceptions
+    // the InterruptedException is one of the exceptions wrapped in ExecutionException
+    val failure = new InterruptedException("future interrupted")
+    Source.futureSource(Future.failed(failure)).receive() shouldBe ChannelClosed.Error(Some(failure))
+  }
+
+  it should "return future's source values" in supervised {
+    Source.futureSource(Future.successful(Source.fromValues(1, 2))).toList shouldBe List(1, 2)
+  }
+}


### PR DESCRIPTION
Creates a source that emits elements from future source when it completes or fails otherwise. The future completion is performed on the provided `ExecutionContext` whereas elements are emitted through `Supervised`. Note that when Future fails with `ExecutionException` then its cause is returned as source failure.

Examples:
```scala
  Source
    .futureSource(Future.failed(new RuntimeException("future failed")))
    .receive()                                                           // ChannelClosed.Error(Some(java.lang.RuntimeException: future failed))
  Source.futureSource(Future.successful(Source.fromValues(1, 2))).toList // List(1, 2)
```