### PR TITLE
feat: implement `orElse` operator

### DIFF
--- a/core/src/test/scala/ox/channels/SourceOpsOrElseTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsOrElseTest.scala
@@ -1,0 +1,26 @@
+package ox.channels
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.*
+
+class SourceOpsOrElseTest extends AnyFlatSpec with Matchers {
+  behavior of "SourceOps.orElse"
+
+  it should "emit elements only from the original source when it is not empty" in supervised {
+    Source.fromValues(1).orElse(Source.fromValues(2, 3)).toList shouldBe List(1)
+  }
+
+  it should "emit elements only from the alternative source when the original source is created empty" in supervised {
+    Source.empty.orElse(Source.fromValues(2, 3)).toList shouldBe List(2, 3)
+  }
+
+  it should "emit elements only from the alternative source when the original source is empty" in supervised {
+    Source.fromValues[Int]().orElse(Source.fromValues(2, 3)).toList shouldBe List(2, 3)
+  }
+
+  it should "return failed source when the original source is failed" in supervised {
+    val failure = new RuntimeException()
+    Source.failed(failure).orElse(Source.fromValues(2, 3)).receive() shouldBe ChannelClosed.Error(Some(failure))
+  }
+}


### PR DESCRIPTION
If a source has no elements then elements from an `alternative` source are emitted to the returned channel. If this source is failed then failure is passed to the returned channel.

Examples:
```scala
  Source.fromValues(1).orElse(Source.fromValues(2, 3)).toList // List(1)
  Source.empty.orElse(Source.fromValues(2, 3)).toList         // List(2, 3)
```

Closes #37.