### PR TITLE
Retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,6 @@ There are some helper methods which might be useful when writing forked code:
 
 * `forever { ... }` repeatedly evaluates the given code block forever
 * `repeatWhile { ... }` repeatedly evaluates the given code block, as long as it returns `true`
-* `retry(times, sleep) { ... }` retries the given block up to the given number of times
 * `uninterruptible { ... }` evaluates the given code block making sure it can't be interrupted
 
 ## Syntax
@@ -633,6 +632,10 @@ Please see [the respective ADR](doc/adr/0001-error-propagation-in-channels.md) f
 
 Channels are back-pressured, as the `.send` operation is blocking until there's a receiver thread available, or if 
 there's enough space in the buffer. The processing space is bound by the total size of channel buffers.
+
+## Retries
+
+The retries mechanism allows to retry a failing operation according to a given policy (e.g. retry 3 times with a 100ms delay between attempts). See the [full docs](doc/retries.md) for details.
 
 ## Kafka sources & drains
 

--- a/core/src/main/scala/ox/control.scala
+++ b/core/src/main/scala/ox/control.scala
@@ -1,7 +1,5 @@
 package ox
 
-import scala.concurrent.duration.FiniteDuration
-
 def forever(f: => Unit): Nothing =
   while true do f
   throw new RuntimeException("can't get here")
@@ -15,25 +13,6 @@ def repeatWhile(f: => Boolean): Unit =
 def repeatUntil(f: => Boolean): Unit =
   var loop = true
   while loop do loop = !f
-
-// TODO: retry schedules
-def retry[T](times: Int, sleep: FiniteDuration)(f: => T): T =
-  try f
-  catch
-    case e: Throwable =>
-      if times > 0
-      then
-        Thread.sleep(sleep.toMillis)
-        retry(times - 1, sleep)(f)
-      else throw e
-
-def retryEither[E, T](times: Int, sleep: FiniteDuration)(f: => Either[E, T]): Either[E, T] =
-  f match
-    case r: Right[E, T] => r
-    case Left(_) if times > 0 =>
-      Thread.sleep(sleep.toMillis)
-      retry(times - 1, sleep)(f)
-    case l: Left[E, T] => l
 
 def uninterruptible[T](f: => T): T =
   scoped {

--- a/core/src/main/scala/ox/retry/Jitter.scala
+++ b/core/src/main/scala/ox/retry/Jitter.scala
@@ -1,0 +1,25 @@
+package ox.retry
+
+/** A random factor used for calculating the delay between subsequent retries when a backoff strategy is used for calculating the delay.
+  *
+  * The purpose of jitter is to avoid clustering of subsequent retries, i.e. to reduce the number of clients calling a service exactly at
+  * the same time - which can result in subsequent failures, contrary to what you would expect from retrying. By introducing randomness to
+  * the delays, the retries become more evenly distributed over time.
+  *
+  * See the <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">AWS Architecture Blog article on backoff and
+  * jitter</a> for a more in-depth explanation.
+  *
+  * Depending on the algorithm, the jitter can affect the delay in different ways - see the concrete variants for more details.
+  */
+enum Jitter:
+  /** No jitter, i.e. the delay just uses an exponential backoff with no adjustments. */
+  case None
+
+  /** Full jitter, i.e. the delay is a random value between 0 and the calculated backoff delay. */
+  case Full
+
+  /** Equal jitter, i.e. the delay is half of the calculated backoff delay plus a random value between 0 and the other half. */
+  case Equal
+
+  /** Decorrelated jitter, i.e. the delay is a random value between the initial delay and the last delay multiplied by 3. */
+  case Decorrelated

--- a/core/src/main/scala/ox/retry/ResultPolicy.scala
+++ b/core/src/main/scala/ox/retry/ResultPolicy.scala
@@ -1,0 +1,37 @@
+package ox.retry
+
+/** A policy that allows to customize when a non-erroneous result is considered successful and when an error is worth retrying (which allows
+  * for failing fast on certain errors).
+  *
+  * @param isSuccess
+  *   A function that determines whether a non-erroneous result is considered successful. By default, every non-erroneous result is
+  *   considered successful.
+  * @param isWorthRetrying
+  *   A function that determines whether an error is worth retrying. By default, all errors are retried.
+  * @tparam E
+  *   The error type of the operation. For operations returning a `T` or a `Try[T]`, this is fixed to `Throwable`. For operations returning
+  *   an `Either[E, T]`, this can be any `E`.
+  * @tparam T
+  *   The successful result type for the operation.
+  */
+case class ResultPolicy[E, T](isSuccess: T => Boolean = (_: T) => true, isWorthRetrying: E => Boolean = (_: E) => true)
+
+object ResultPolicy:
+  /** A policy that considers every non-erroneous result successful and retries on any error. */
+  def default[E, T]: ResultPolicy[E, T] = ResultPolicy()
+
+  /** A policy that customizes when a non-erroneous result is considered successful, and retries all errors
+    *
+    * @param isSuccess
+    *   A predicate that indicates whether a non-erroneous result is considered successful.
+    */
+  def successfulWhen[E, T](isSuccess: T => Boolean): ResultPolicy[E, T] = ResultPolicy(isSuccess = isSuccess)
+
+  /** A policy that customizes which errors are retried, and considers every non-erroneous result successful
+    * @param isWorthRetrying
+    *   A predicate that indicates whether an erroneous result should be retried..
+    */
+  def retryWhen[E, T](isWorthRetrying: E => Boolean): ResultPolicy[E, T] = ResultPolicy(isWorthRetrying = isWorthRetrying)
+
+  /** A policy that considers every non-erroneous result successful and never retries any error, i.e. fails fast */
+  def neverRetry[E, T]: ResultPolicy[E, T] = ResultPolicy(isWorthRetrying = _ => false)

--- a/core/src/main/scala/ox/retry/RetryPolicy.scala
+++ b/core/src/main/scala/ox/retry/RetryPolicy.scala
@@ -6,8 +6,8 @@ import scala.util.Random
 case class RetryPolicy[E, T](schedule: Schedule, resultPolicy: ResultPolicy[E, T] = ResultPolicy.default[E, T])
 
 object RetryPolicy:
-  def direct[E, T](maxRetries: Int): RetryPolicy[E, T] = RetryPolicy(Schedule.Direct(maxRetries))
-  def directForever[E, T]: RetryPolicy[E, T] = RetryPolicy(Schedule.Direct.forever)
+  def immediate[E, T](maxRetries: Int): RetryPolicy[E, T] = RetryPolicy(Schedule.Immediate(maxRetries))
+  def immediateForever[E, T]: RetryPolicy[E, T] = RetryPolicy(Schedule.Immediate.forever)
 
   def delay[E, T](maxRetries: Int, delay: FiniteDuration): RetryPolicy[E, T] = RetryPolicy(Schedule.Delay(maxRetries, delay))
   def delayForever[E, T](delay: FiniteDuration): RetryPolicy[E, T] = RetryPolicy(Schedule.Delay.forever(delay))
@@ -40,10 +40,10 @@ object Schedule:
 
   sealed trait Infinite extends Schedule
 
-  case class Direct(maxRetries: Int) extends Finite:
+  case class Immediate(maxRetries: Int) extends Finite:
     override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = Duration.Zero
 
-  object Direct:
+  object Immediate:
     def forever: Infinite = DirectForever
 
   case object DirectForever extends Infinite:

--- a/core/src/main/scala/ox/retry/RetryPolicy.scala
+++ b/core/src/main/scala/ox/retry/RetryPolicy.scala
@@ -37,7 +37,7 @@ object RetryPolicy:
   case class Backoff(
       maxRetries: Int,
       initialDelay: FiniteDuration,
-      maxDelay: FiniteDuration = 1.day,
+      maxDelay: FiniteDuration = 1.minute,
       jitter: Jitter = Jitter.None
   ) extends Finite:
     override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =

--- a/core/src/main/scala/ox/retry/RetryPolicy.scala
+++ b/core/src/main/scala/ox/retry/RetryPolicy.scala
@@ -1,0 +1,76 @@
+package ox.retry
+
+import scala.concurrent.duration.*
+import scala.util.Random
+
+enum Jitter:
+  case None, Full, Equal, Decorrelated
+
+trait RetryPolicy:
+  def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration
+
+object RetryPolicy:
+
+  trait Finite extends RetryPolicy:
+    def maxRetries: Int
+
+  trait Infinite extends RetryPolicy
+
+  case class Direct(maxRetries: Int) extends Finite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = Duration.Zero
+
+  object Direct:
+    def forever: Infinite = DirectForever
+
+  case object DirectForever extends Infinite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = Duration.Zero
+
+  case class Delay(maxRetries: Int, delay: FiniteDuration) extends Finite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = delay
+
+  object Delay:
+    def forever(delay: FiniteDuration): Infinite = DelayForever(delay)
+
+  private case class DelayForever(delay: FiniteDuration) extends Infinite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = delay
+
+  case class Backoff(
+      maxRetries: Int,
+      initialDelay: FiniteDuration,
+      maxDelay: FiniteDuration = 1.day,
+      jitter: Jitter = Jitter.None
+  ) extends Finite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
+      Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)
+
+  object Backoff:
+    private[retry] def delay(attempt: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration): FiniteDuration =
+      // converting Duration <-> Long back and forth to avoid exceeding maximum duration
+      (initialDelay.toMillis * Math.pow(2, attempt)).toLong.min(maxDelay.toMillis).millis
+
+    private[retry] def nextDelay(
+        attempt: Int,
+        initialDelay: FiniteDuration,
+        maxDelay: FiniteDuration,
+        jitter: Jitter,
+        lastDelay: Option[FiniteDuration]
+    ): FiniteDuration =
+      def backoffDelay = Backoff.delay(attempt, initialDelay, maxDelay)
+
+      jitter match
+        case Jitter.None => backoffDelay
+        case Jitter.Full => Random.between(0, backoffDelay.toMillis).millis
+        case Jitter.Equal =>
+          val backoff = backoffDelay.toMillis
+          (backoff / 2 + Random.between(0, backoff / 2)).millis
+        case Jitter.Decorrelated =>
+          val last = lastDelay.getOrElse(initialDelay).toMillis
+          Random.between(initialDelay.toMillis, last * 3).millis
+
+    def forever(initialDelay: FiniteDuration, maxDelay: FiniteDuration = 1.day, jitter: Jitter = Jitter.None): Infinite =
+      BackoffForever(initialDelay, maxDelay, jitter)
+
+  private case class BackoffForever(initialDelay: FiniteDuration, maxDelay: FiniteDuration = 1.day, jitter: Jitter = Jitter.None)
+      extends Infinite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
+      Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)

--- a/core/src/main/scala/ox/retry/RetryPolicy.scala
+++ b/core/src/main/scala/ox/retry/RetryPolicy.scala
@@ -1,17 +1,79 @@
 package ox.retry
 
 import scala.concurrent.duration.*
-import scala.util.Random
 
+/** A policy that defines how to retry a failed operation.
+  *
+  * @param schedule
+  *   The retry schedule which determines the maximum number of retries and the delay between subsequent attempts to execute the operation.
+  *   See [[Schedule]] for more details.
+  * @param resultPolicy
+  *   A policy that allows to customize when a non-erroneous result is considered successful and when an error is worth retrying (which
+  *   allows for failing fast on certain errors). See [[ResultPolicy]] for more details.
+  * @tparam E
+  *   The error type of the operation. For operations returning a `T` or a `Try[T]`, this is fixed to `Throwable`. For operations returning
+  *   an `Either[E, T]`, this can be any `E`.
+  * @tparam T
+  *   The successful result type for the operation.
+  */
 case class RetryPolicy[E, T](schedule: Schedule, resultPolicy: ResultPolicy[E, T] = ResultPolicy.default[E, T])
 
 object RetryPolicy:
+  /** Creates a policy that retries up to a given number of times, with no delay between subsequent attempts, using a default
+    * [[ResultPolicy]].
+    *
+    * This is a shorthand for {{{RetryPolicy(Schedule.Immediate(maxRetries))}}}
+    *
+    * @param maxRetries
+    *   The maximum number of retries.
+    */
   def immediate[E, T](maxRetries: Int): RetryPolicy[E, T] = RetryPolicy(Schedule.Immediate(maxRetries))
+
+  /** Creates a policy that retries indefinitely, with no delay between subsequent attempts, using a default [[ResultPolicy]].
+    *
+    * This is a shorthand for {{{RetryPolicy(Schedule.Immediate.forever)}}}
+    */
   def immediateForever[E, T]: RetryPolicy[E, T] = RetryPolicy(Schedule.Immediate.forever)
 
+  /** Creates a policy that retries up to a given number of times, with a fixed delay between subsequent attempts, using a default
+    * [[ResultPolicy]].
+    *
+    * This is a shorthand for {{{RetryPolicy(Schedule.Delay(maxRetries, delay))}}}
+    *
+    * @param maxRetries
+    *   The maximum number of retries.
+    * @param delay
+    *   The delay between subsequent attempts.
+    */
   def delay[E, T](maxRetries: Int, delay: FiniteDuration): RetryPolicy[E, T] = RetryPolicy(Schedule.Delay(maxRetries, delay))
+
+  /** Creates a policy that retries indefinitely, with a fixed delay between subsequent attempts, using a default [[ResultPolicy]].
+    *
+    * This is a shorthand for {{{RetryPolicy(Schedule.Delay.forever(delay))}}}
+    *
+    * @param delay
+    *   The delay between subsequent attempts.
+    */
   def delayForever[E, T](delay: FiniteDuration): RetryPolicy[E, T] = RetryPolicy(Schedule.Delay.forever(delay))
 
+  /** Creates a policy that retries up to a given number of times, with an increasing delay (backoff) between subsequent attempts, using a
+    * default [[ResultPolicy]].
+    *
+    * The backoff is exponential with base 2 (i.e. the next delay is twice as long as the previous one), starting at the given initial delay
+    * and capped at the given maximum delay.
+    *
+    * This is a shorthand for {{{RetryPolicy(Schedule.Backoff(maxRetries, initialDelay, maxDelay, jitter))}}}
+    *
+    * @param maxRetries
+    *   The maximum number of retries.
+    * @param initialDelay
+    *   The delay before the first retry.
+    * @param maxDelay
+    *   The maximum delay between subsequent retries. Defaults to 1 minute.
+    * @param jitter
+    *   A random factor used for calculating the delay between subsequent retries. See [[Jitter]] for more details. Defaults to no jitter,
+    * i.e. an exponential backoff with no adjustments.
+    */
   def backoff[E, T](
       maxRetries: Int,
       initialDelay: FiniteDuration,
@@ -20,92 +82,25 @@ object RetryPolicy:
   ): RetryPolicy[E, T] =
     RetryPolicy(Schedule.Backoff(maxRetries, initialDelay, maxDelay, jitter))
 
+  /** Creates a policy that retries indefinitely, with an increasing delay (backoff) between subsequent attempts, using a default
+    * [[ResultPolicy]].
+    *
+    * The backoff is exponential with base 2 (i.e. the next delay is twice as long as the previous one), starting at the given initial delay
+    * and capped at the given maximum delay.
+    *
+    * This is a shorthand for {{{RetryPolicy(Schedule.Backoff.forever(initialDelay, maxDelay, jitter))}}}
+    *
+    * @param initialDelay
+    *   The delay before the first retry.
+    * @param maxDelay
+    *   The maximum delay between subsequent retries. Defaults to 1 minute.
+    * @param jitter
+    *   A random factor used for calculating the delay between subsequent retries. See [[Jitter]] for more details. Defaults to no jitter,
+    * i.e. an exponential backoff with no adjustments.
+    */
   def backoffForever[E, T](
       initialDelay: FiniteDuration,
       maxDelay: FiniteDuration = 1.minute,
       jitter: Jitter = Jitter.None
   ): RetryPolicy[E, T] =
     RetryPolicy(Schedule.Backoff.forever(initialDelay, maxDelay, jitter))
-
-enum Jitter:
-  case None, Full, Equal, Decorrelated
-
-sealed trait Schedule:
-  def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration
-
-object Schedule:
-
-  sealed trait Finite extends Schedule:
-    def maxRetries: Int
-
-  sealed trait Infinite extends Schedule
-
-  case class Immediate(maxRetries: Int) extends Finite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = Duration.Zero
-
-  object Immediate:
-    def forever: Infinite = DirectForever
-
-  case object DirectForever extends Infinite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = Duration.Zero
-
-  case class Delay(maxRetries: Int, delay: FiniteDuration) extends Finite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = delay
-
-  object Delay:
-    def forever(delay: FiniteDuration): Infinite = DelayForever(delay)
-
-  private case class DelayForever(delay: FiniteDuration) extends Infinite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = delay
-
-  case class Backoff(
-      maxRetries: Int,
-      initialDelay: FiniteDuration,
-      maxDelay: FiniteDuration = 1.minute,
-      jitter: Jitter = Jitter.None
-  ) extends Finite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
-      Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)
-
-  object Backoff:
-    private[retry] def delay(attempt: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration): FiniteDuration =
-      // converting Duration <-> Long back and forth to avoid exceeding maximum duration
-      (initialDelay.toMillis * Math.pow(2, attempt)).toLong.min(maxDelay.toMillis).millis
-
-    private[retry] def nextDelay(
-        attempt: Int,
-        initialDelay: FiniteDuration,
-        maxDelay: FiniteDuration,
-        jitter: Jitter,
-        lastDelay: Option[FiniteDuration]
-    ): FiniteDuration =
-      def backoffDelay = Backoff.delay(attempt, initialDelay, maxDelay)
-
-      jitter match
-        case Jitter.None => backoffDelay
-        case Jitter.Full => Random.between(0, backoffDelay.toMillis).millis
-        case Jitter.Equal =>
-          val backoff = backoffDelay.toMillis
-          (backoff / 2 + Random.between(0, backoff / 2)).millis
-        case Jitter.Decorrelated =>
-          val last = lastDelay.getOrElse(initialDelay).toMillis
-          Random.between(initialDelay.toMillis, last * 3).millis
-
-    def forever(initialDelay: FiniteDuration, maxDelay: FiniteDuration = 1.day, jitter: Jitter = Jitter.None): Infinite =
-      BackoffForever(initialDelay, maxDelay, jitter)
-
-  private case class BackoffForever(initialDelay: FiniteDuration, maxDelay: FiniteDuration = 1.day, jitter: Jitter = Jitter.None)
-      extends Infinite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
-      Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)
-
-case class ResultPolicy[E, T](isSuccess: T => Boolean = (_: T) => true, isWorthRetrying: E => Boolean = (_: E) => true)
-
-object ResultPolicy:
-  def default[E, T]: ResultPolicy[E, T] = ResultPolicy()
-
-  def successfulWhen[E, T](f: T => Boolean): ResultPolicy[E, T] = ResultPolicy(isSuccess = f)
-
-  def retryWhen[E, T](f: E => Boolean): ResultPolicy[E, T] = ResultPolicy(isWorthRetrying = f)
-
-  def neverRetry[E, T]: ResultPolicy[E, T] = ResultPolicy(isWorthRetrying = _ => false)

--- a/core/src/main/scala/ox/retry/Schedule.scala
+++ b/core/src/main/scala/ox/retry/Schedule.scala
@@ -1,0 +1,119 @@
+package ox.retry
+
+import scala.concurrent.duration.*
+import scala.util.Random
+
+private[retry] sealed trait Schedule:
+  def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration
+
+object Schedule:
+
+  private[retry] sealed trait Finite extends Schedule:
+    def maxRetries: Int
+
+  private[retry] sealed trait Infinite extends Schedule
+
+  /** A schedule that retries up to a given number of times, with no delay between subsequent attempts.
+    *
+    * @param maxRetries
+    *   The maximum number of retries.
+    */
+  case class Immediate(maxRetries: Int) extends Finite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = Duration.Zero
+
+  object Immediate:
+    /** A schedule that retries indefinitely, with no delay between subsequent attempts. */
+    def forever: Infinite = ImmediateForever
+
+  private case object ImmediateForever extends Infinite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = Duration.Zero
+
+  /** A schedule that retries up to a given number of times, with a fixed delay between subsequent attempts.
+    *
+    * @param maxRetries
+    *   The maximum number of retries.
+    * @param delay
+    *   The delay between subsequent attempts.
+    */
+  case class Delay(maxRetries: Int, delay: FiniteDuration) extends Finite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = delay
+
+  object Delay:
+    /** A schedule that retries indefinitely, with a fixed delay between subsequent attempts.
+      *
+      * @param delay
+      *   The delay between subsequent attempts.
+      */
+    def forever(delay: FiniteDuration): Infinite = DelayForever(delay)
+
+  case class DelayForever private[retry] (delay: FiniteDuration) extends Infinite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = delay
+
+  /** A schedule that retries up to a given number of times, with an increasing delay (backoff) between subsequent attempts.
+    *
+    * The backoff is exponential with base 2 (i.e. the next delay is twice as long as the previous one), starting at the given initial delay
+    * and capped at the given maximum delay.
+    *
+    * @param maxRetries
+    *   The maximum number of retries.
+    * @param initialDelay
+    *   The delay before the first retry.
+    * @param maxDelay
+    *   The maximum delay between subsequent retries.
+    * @param jitter
+    *   A random factor used for calculating the delay between subsequent retries. See [[Jitter]] for more details. Defaults to no jitter,
+    * i.e. an exponential backoff with no adjustments.
+    */
+  case class Backoff(
+      maxRetries: Int,
+      initialDelay: FiniteDuration,
+      maxDelay: FiniteDuration = 1.minute,
+      jitter: Jitter = Jitter.None
+  ) extends Finite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
+      Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)
+
+  object Backoff:
+    private[retry] def delay(attempt: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration): FiniteDuration =
+      // converting Duration <-> Long back and forth to avoid exceeding maximum duration
+      (initialDelay.toMillis * Math.pow(2, attempt)).toLong.min(maxDelay.toMillis).millis
+
+    private[retry] def nextDelay(
+        attempt: Int,
+        initialDelay: FiniteDuration,
+        maxDelay: FiniteDuration,
+        jitter: Jitter,
+        lastDelay: Option[FiniteDuration]
+    ): FiniteDuration =
+      def backoffDelay = Backoff.delay(attempt, initialDelay, maxDelay)
+
+      jitter match
+        case Jitter.None => backoffDelay
+        case Jitter.Full => Random.between(0, backoffDelay.toMillis).millis
+        case Jitter.Equal =>
+          val backoff = backoffDelay.toMillis
+          (backoff / 2 + Random.between(0, backoff / 2)).millis
+        case Jitter.Decorrelated =>
+          val last = lastDelay.getOrElse(initialDelay).toMillis
+          Random.between(initialDelay.toMillis, last * 3).millis
+
+    /** A schedule that retries indefinitely, with an increasing delay (backoff) between subsequent attempts.
+      *
+      * The backoff is exponential with base 2 (i.e. the next delay is twice as long as the previous one), starting at the given initial
+      * delay and capped at the given maximum delay.
+      *
+      * @param initialDelay
+      *   The delay before the first retry.
+      * @param maxDelay
+      *   The maximum delay between subsequent retries.
+      * @param jitter
+      *   A random factor used for calculating the delay between subsequent retries. See [[Jitter]] for more details. Defaults to no jitter,
+      * i.e. an exponential backoff with no adjustments.
+      */
+    def forever(initialDelay: FiniteDuration, maxDelay: FiniteDuration = 1.minute, jitter: Jitter = Jitter.None): Infinite =
+      BackoffForever(initialDelay, maxDelay, jitter)
+
+  case class BackoffForever private[retry] (initialDelay: FiniteDuration, maxDelay: FiniteDuration = 1.minute, jitter: Jitter = Jitter.None)
+      extends Infinite:
+    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
+      Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)

--- a/core/src/main/scala/ox/retry/retry.scala
+++ b/core/src/main/scala/ox/retry/retry.scala
@@ -4,13 +4,8 @@ import scala.annotation.tailrec
 import scala.concurrent.duration.*
 import scala.util.{Random, Try}
 
-sealed trait Jitter
-
-object Jitter:
-  case object None extends Jitter
-  case object Full extends Jitter
-  case object Equal extends Jitter
-  case object Decorrelated extends Jitter
+enum Jitter:
+  case None, Full, Equal, Decorrelated
 
 trait RetryPolicy:
   def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration

--- a/core/src/main/scala/ox/retry/retry.scala
+++ b/core/src/main/scala/ox/retry/retry.scala
@@ -2,79 +2,7 @@ package ox.retry
 
 import scala.annotation.tailrec
 import scala.concurrent.duration.*
-import scala.util.{Random, Try}
-
-enum Jitter:
-  case None, Full, Equal, Decorrelated
-
-trait RetryPolicy:
-  def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration
-
-object RetryPolicy:
-
-  trait Finite extends RetryPolicy:
-    def maxRetries: Int
-
-  trait Infinite extends RetryPolicy
-
-  case class Direct(maxRetries: Int) extends Finite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = Duration.Zero
-
-  object Direct:
-    def forever: Infinite = DirectForever
-
-  case object DirectForever extends Infinite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = Duration.Zero
-
-  case class Delay(maxRetries: Int, delay: FiniteDuration) extends Finite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = delay
-
-  object Delay:
-    def forever(delay: FiniteDuration): Infinite = DelayForever(delay)
-
-  private case class DelayForever(delay: FiniteDuration) extends Infinite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration = delay
-
-  case class Backoff(
-      maxRetries: Int,
-      initialDelay: FiniteDuration,
-      maxDelay: FiniteDuration = 1.day,
-      jitter: Jitter = Jitter.None
-  ) extends Finite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
-      Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)
-
-  object Backoff:
-    private[retry] def delay(attempt: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration): FiniteDuration =
-      // converting Duration <-> Long back and forth to avoid exceeding maximum duration
-      (initialDelay.toMillis * Math.pow(2, attempt)).toLong.min(maxDelay.toMillis).millis
-
-    private[retry] def nextDelay(
-        attempt: Int,
-        initialDelay: FiniteDuration,
-        maxDelay: FiniteDuration,
-        jitter: Jitter,
-        lastDelay: Option[FiniteDuration]
-    ): FiniteDuration =
-      def backoffDelay = Backoff.delay(attempt, initialDelay, maxDelay)
-
-      jitter match
-        case Jitter.None => backoffDelay
-        case Jitter.Full => Random.between(0, backoffDelay.toMillis).millis
-        case Jitter.Equal =>
-          val backoff = backoffDelay.toMillis
-          (backoff / 2 + Random.between(0, backoff / 2)).millis
-        case Jitter.Decorrelated =>
-          val last = lastDelay.getOrElse(initialDelay).toMillis
-          Random.between(initialDelay.toMillis, last * 3).millis
-
-    def forever(initialDelay: FiniteDuration, maxDelay: FiniteDuration = 1.day, jitter: Jitter = Jitter.None): Infinite =
-      BackoffForever(initialDelay, maxDelay, jitter)
-
-  private case class BackoffForever(initialDelay: FiniteDuration, maxDelay: FiniteDuration = 1.day, jitter: Jitter = Jitter.None)
-      extends Infinite:
-    override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
-      Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)
+import scala.util.Try
 
 // overloaded variants for function
 def retry[T](f: => T)(policy: RetryPolicy): T =
@@ -88,6 +16,23 @@ def retry[T](f: => T, isWorthRetrying: Throwable => Boolean)(policy: RetryPolicy
 
 def retry[T](f: => T, isSuccess: T => Boolean, isWorthRetrying: Throwable => Boolean)(policy: RetryPolicy): T =
   retry(Try(f), isSuccess, isWorthRetrying)(policy).get
+
+// overloaded variants for Try
+def retry[T](f: => Try[T])(policy: RetryPolicy)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
+  retry(f, _ => true, _ => true)(policy)(using dummy1, dummy2)
+
+def retry[T](f: => Try[T], isSuccess: T => Boolean)(policy: RetryPolicy)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
+  retry(f, isSuccess, _ => true)(policy)(using dummy1, dummy2)
+
+def retry[T](f: => Try[T], isWorthRetrying: Throwable => Boolean)(
+    policy: RetryPolicy
+)(using dummy1: DummyImplicit, dummy2: DummyImplicit, dummy3: DummyImplicit): Try[T] =
+  retry(f, _ => true, isWorthRetrying)(policy)(using dummy1, dummy2)
+
+def retry[T](f: => Try[T], isSuccess: T => Boolean, isWorthRetrying: Throwable => Boolean)(
+    policy: RetryPolicy
+)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
+  retry(f.toEither, isSuccess, isWorthRetrying)(policy)(using dummy1).toTry
 
 // overloaded variants for Either
 def retry[E, T](f: => Either[E, T])(policy: RetryPolicy)(using dummy: DummyImplicit): Either[E, T] =
@@ -128,20 +73,3 @@ def retry[E, T](f: => Either[E, T], isSuccess: T => Boolean, isWorthRetrying: E 
     case _                          => None
 
   loop(0, remainingAttempts, None)
-
-// overloaded variants for Try
-def retry[T](f: => Try[T])(policy: RetryPolicy)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
-  retry(f, _ => true, _ => true)(policy)(using dummy1, dummy2)
-
-def retry[T](f: => Try[T], isSuccess: T => Boolean)(policy: RetryPolicy)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
-  retry(f, isSuccess, _ => true)(policy)(using dummy1, dummy2)
-
-def retry[T](f: => Try[T], isWorthRetrying: Throwable => Boolean)(
-    policy: RetryPolicy
-)(using dummy1: DummyImplicit, dummy2: DummyImplicit, dummy3: DummyImplicit): Try[T] =
-  retry(f, _ => true, isWorthRetrying)(policy)(using dummy1, dummy2)
-
-def retry[T](f: => Try[T], isSuccess: T => Boolean, isWorthRetrying: Throwable => Boolean)(
-    policy: RetryPolicy
-)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
-  retry(f.toEither, isSuccess, isWorthRetrying)(policy)(using dummy1).toTry

--- a/core/src/main/scala/ox/retry/retry.scala
+++ b/core/src/main/scala/ox/retry/retry.scala
@@ -1,0 +1,50 @@
+package ox.retry
+
+import scala.concurrent.duration.*
+import scala.util.Try
+
+sealed trait Jitter
+
+object Jitter:
+  case object None extends Jitter
+  case object Full extends Jitter
+  case object Equal extends Jitter
+  case object Decorrelated extends Jitter
+
+trait RetryPolicy:
+  def maxRetries: Int
+
+object RetryPolicy:
+  case class Direct(maxRetries: Int) extends RetryPolicy
+  case class Delay(maxRetries: Int, delay: FiniteDuration) extends RetryPolicy
+  case class Backoff(maxRetries: Int, initialDelay: FiniteDuration, jitter: Jitter = Jitter.None) extends RetryPolicy
+
+def retry[T](f: => T)(policy: RetryPolicy): T =
+  retry(f, _ => true)(policy)
+
+def retry[T](f: => T, isSuccess: T => Boolean)(policy: RetryPolicy): T =
+  retry(Try(f), isSuccess)(policy).get
+
+def retry[E, T](f: => Either[E, T])(policy: RetryPolicy)(using dummy: DummyImplicit): Either[E, T] =
+  retry(f, _ => true)(policy)(using dummy)
+
+def retry[E, T](f: => Either[E, T], isSuccess: T => Boolean)(policy: RetryPolicy)(using dummy: DummyImplicit): Either[E, T] =
+  def loop(remainingAttempts: Int): Either[E, T] =
+    def nextAttemptOr(e: => Either[E, T]) =
+      if remainingAttempts > 0 then
+        // TODO sleep if needed
+        loop(remainingAttempts - 1)
+      else e
+
+    f match
+      case Left(error)                         => nextAttemptOr(Left(error))
+      case Right(result) if !isSuccess(result) => nextAttemptOr(Right(result))
+      case right                               => right
+
+  loop(policy.maxRetries)
+
+def retry[T](f: => Try[T])(policy: RetryPolicy)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
+  retry(f, _ => true)(policy)(using dummy1, dummy2)
+
+def retry[T](f: => Try[T], isSuccess: T => Boolean)(policy: RetryPolicy)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
+  retry(f.toEither, isSuccess)(policy)(using dummy1).toTry

--- a/core/src/main/scala/ox/retry/retry.scala
+++ b/core/src/main/scala/ox/retry/retry.scala
@@ -7,10 +7,10 @@ import scala.util.Try
 def retry[T](f: => T)(policy: RetryPolicy[Throwable, T]): T =
   retry(Try(f))(policy).get
 
-def retry[T](f: => Try[T])(policy: RetryPolicy[Throwable, T])(using DummyImplicit): Try[T] =
+def retry[T](f: => Try[T])(policy: RetryPolicy[Throwable, T]): Try[T] =
   retry(f.toEither)(policy).toTry
 
-def retry[E, T](f: => Either[E, T])(policy: RetryPolicy[E, T])(using dummy1: DummyImplicit, dummy2: DummyImplicit): Either[E, T] =
+def retry[E, T](f: => Either[E, T])(policy: RetryPolicy[E, T]): Either[E, T] =
   @tailrec
   def loop(attempt: Int, remainingAttempts: Option[Int], lastDelay: Option[FiniteDuration]): Either[E, T] =
     def sleepIfNeeded =

--- a/core/src/main/scala/ox/retry/retry.scala
+++ b/core/src/main/scala/ox/retry/retry.scala
@@ -41,7 +41,7 @@ object RetryPolicy:
           val last = lastDelay.getOrElse(initialDelay).toMillis
           Random.between(initialDelay.toMillis, last * 3).millis
 
-  private[retry]   object Backoff:
+  private[retry] object Backoff:
     def delay(attempt: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration): FiniteDuration =
       (initialDelay * Math.pow(2, attempt).toLong).min(maxDelay)
 

--- a/core/src/main/scala/ox/retry/retry.scala
+++ b/core/src/main/scala/ox/retry/retry.scala
@@ -61,7 +61,7 @@ def retry[E, T](operation: => Either[E, T])(policy: RetryPolicy[E, T]): Either[E
         else right
 
   val remainingAttempts = policy.schedule match
-    case policy: Schedule.Finite => Some(policy.maxRetries)
-    case _                       => None
+    case finiteSchedule: Schedule.Finite => Some(finiteSchedule.maxRetries)
+    case _                               => None
 
   loop(0, remainingAttempts, None)

--- a/core/src/main/scala/ox/retry/retry.scala
+++ b/core/src/main/scala/ox/retry/retry.scala
@@ -4,72 +4,34 @@ import scala.annotation.tailrec
 import scala.concurrent.duration.*
 import scala.util.Try
 
-// overloaded variants for function
-def retry[T](f: => T)(policy: RetryPolicy): T =
-  retry(f, _ => true, _ => true)(policy)
+def retry[T](f: => T)(policy: RetryPolicy[Throwable, T]): T =
+  retry(Try(f))(policy).get
 
-def retry[T](f: => T, isSuccess: T => Boolean)(policy: RetryPolicy): T =
-  retry(f, isSuccess, _ => true)(policy)
+def retry[T](f: => Try[T])(policy: RetryPolicy[Throwable, T])(using DummyImplicit): Try[T] =
+  retry(f.toEither)(policy).toTry
 
-def retry[T](f: => T, isWorthRetrying: Throwable => Boolean)(policy: RetryPolicy)(using DummyImplicit): T =
-  retry(f, _ => true, isWorthRetrying)(policy)
-
-def retry[T](f: => T, isSuccess: T => Boolean, isWorthRetrying: Throwable => Boolean)(policy: RetryPolicy): T =
-  retry(Try(f), isSuccess, isWorthRetrying)(policy).get
-
-// overloaded variants for Try
-def retry[T](f: => Try[T])(policy: RetryPolicy)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
-  retry(f, _ => true, _ => true)(policy)(using dummy1, dummy2)
-
-def retry[T](f: => Try[T], isSuccess: T => Boolean)(policy: RetryPolicy)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
-  retry(f, isSuccess, _ => true)(policy)(using dummy1, dummy2)
-
-def retry[T](f: => Try[T], isWorthRetrying: Throwable => Boolean)(
-    policy: RetryPolicy
-)(using dummy1: DummyImplicit, dummy2: DummyImplicit, dummy3: DummyImplicit): Try[T] =
-  retry(f, _ => true, isWorthRetrying)(policy)(using dummy1, dummy2)
-
-def retry[T](f: => Try[T], isSuccess: T => Boolean, isWorthRetrying: Throwable => Boolean)(
-    policy: RetryPolicy
-)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Try[T] =
-  retry(f.toEither, isSuccess, isWorthRetrying)(policy)(using dummy1).toTry
-
-// overloaded variants for Either
-def retry[E, T](f: => Either[E, T])(policy: RetryPolicy)(using dummy: DummyImplicit): Either[E, T] =
-  retry(f, _ => true, _ => true)(policy)(using dummy)
-
-def retry[E, T](f: => Either[E, T], isSuccess: T => Boolean)(policy: RetryPolicy)(using dummy: DummyImplicit): Either[E, T] =
-  retry(f, isSuccess, _ => true)(policy)(using dummy)
-
-def retry[E, T](f: => Either[E, T], isWorthRetrying: E => Boolean)(
-    policy: RetryPolicy
-)(using dummy1: DummyImplicit, dummy2: DummyImplicit): Either[E, T] =
-  retry(f, _ => true, isWorthRetrying)(policy)(using dummy1)
-
-def retry[E, T](f: => Either[E, T], isSuccess: T => Boolean, isWorthRetrying: E => Boolean)(policy: RetryPolicy)(using
-    DummyImplicit
-): Either[E, T] =
+def retry[E, T](f: => Either[E, T])(policy: RetryPolicy[E, T])(using dummy1: DummyImplicit, dummy2: DummyImplicit): Either[E, T] =
   @tailrec
   def loop(attempt: Int, remainingAttempts: Option[Int], lastDelay: Option[FiniteDuration]): Either[E, T] =
     def sleepIfNeeded =
-      val delay = policy.nextDelay(attempt + 1, lastDelay).toMillis
+      val delay = policy.schedule.nextDelay(attempt + 1, lastDelay).toMillis
       if (delay > 0) Thread.sleep(delay)
       delay
 
     f match
       case left @ Left(error) =>
-        if isWorthRetrying(error) && remainingAttempts.forall(_ > 0) then
+        if policy.resultPolicy.isWorthRetrying(error) && remainingAttempts.forall(_ > 0) then
           val delay = sleepIfNeeded
           loop(attempt + 1, remainingAttempts.map(_ - 1), Some(delay.millis))
         else left
       case right @ Right(result) =>
-        if !isSuccess(result) && remainingAttempts.forall(_ > 0) then
+        if !policy.resultPolicy.isSuccess(result) && remainingAttempts.forall(_ > 0) then
           val delay = sleepIfNeeded
           loop(attempt + 1, remainingAttempts.map(_ - 1), Some(delay.millis))
         else right
 
-  val remainingAttempts = policy match
-    case policy: RetryPolicy.Finite => Some(policy.maxRetries)
-    case _                          => None
+  val remainingAttempts = policy.schedule match
+    case policy: Schedule.Finite => Some(policy.maxRetries)
+    case _                       => None
 
   loop(0, remainingAttempts, None)

--- a/core/src/main/scala/ox/retry/retry.scala
+++ b/core/src/main/scala/ox/retry/retry.scala
@@ -22,8 +22,13 @@ object RetryPolicy:
   case class Delay(maxRetries: Int, delay: FiniteDuration) extends RetryPolicy:
     def nextDelay(attempt: Int): FiniteDuration = delay
 
-  case class Backoff(maxRetries: Int, initialDelay: FiniteDuration, jitter: Jitter = Jitter.None) extends RetryPolicy:
-    def nextDelay(attempt: Int): FiniteDuration = initialDelay * Math.pow(2, attempt).toLong // TODO jitter
+  case class Backoff(
+      maxRetries: Int,
+      initialDelay: FiniteDuration,
+      maxDelay: FiniteDuration = 1.day,
+      jitter: Jitter = Jitter.None
+  ) extends RetryPolicy:
+    def nextDelay(attempt: Int): FiniteDuration = (initialDelay * Math.pow(2, attempt).toLong).min(maxDelay) // TODO jitter
 
 def retry[T](f: => T)(policy: RetryPolicy): T =
   retry(f, _ => true)(policy)

--- a/core/src/main/scala/ox/syntax.scala
+++ b/core/src/main/scala/ox/syntax.scala
@@ -1,9 +1,16 @@
 package ox
 
+import ox.retry.RetryPolicy
+
 import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
 
 object syntax:
   extension [T](f: => T) def forever: Fork[Nothing] = ox.forever(f)
+
+  extension [T](f: => T) def retry(policy: RetryPolicy[Throwable, T]): T = ox.retry.retry(f)(policy)
+  extension [T](f: => Try[T]) def retry(policy: RetryPolicy[Throwable, T]): Try[T] = ox.retry.retry(f)(policy)
+  extension [E, T](f: => Either[E, T]) def retry(policy: RetryPolicy[E, T]): Either[E, T] = ox.retry.retry(f)(policy)
 
   extension [T](f: => T)(using Ox)
     def fork: Fork[T] = ox.fork(f)

--- a/core/src/main/scala/ox/syntax.scala
+++ b/core/src/main/scala/ox/syntax.scala
@@ -3,9 +3,7 @@ package ox
 import scala.concurrent.duration.FiniteDuration
 
 object syntax:
-  extension [T](f: => T)
-    def forever: Fork[Nothing] = ox.forever(f)
-    def retry(times: Int, sleep: FiniteDuration): T = ox.retry(times, sleep)(f)
+  extension [T](f: => T) def forever: Fork[Nothing] = ox.forever(f)
 
   extension [T](f: => T)(using Ox)
     def fork: Fork[T] = ox.fork(f)

--- a/core/src/test/scala/ox/ElapsedTime.scala
+++ b/core/src/test/scala/ox/ElapsedTime.scala
@@ -1,0 +1,12 @@
+package ox
+
+import scala.concurrent.duration.*
+
+trait ElapsedTime {
+  
+  def measure[T](f: => T): (T, Duration) =
+    val before = System.currentTimeMillis()
+    val result = f
+    val after = System.currentTimeMillis();
+    (result, (after - before).millis)
+}

--- a/core/src/test/scala/ox/ElapsedTime.scala
+++ b/core/src/test/scala/ox/ElapsedTime.scala
@@ -3,10 +3,10 @@ package ox
 import scala.concurrent.duration.*
 
 trait ElapsedTime {
-  
+
   def measure[T](f: => T): (T, Duration) =
-    val before = System.currentTimeMillis()
+    val before = System.nanoTime()
     val result = f
-    val after = System.currentTimeMillis();
-    (result, (after - before).millis)
+    val after = System.nanoTime()
+    (result, (after - before).nanos)
 }

--- a/core/src/test/scala/ox/channels/SourceOpsThrottleTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsThrottleTest.scala
@@ -5,8 +5,9 @@ import org.scalatest.matchers.should.Matchers
 import ox.*
 
 import scala.concurrent.duration.*
+import ox.ElapsedTime
 
-class SourceOpsThrottleTest extends AnyFlatSpec with Matchers {
+class SourceOpsThrottleTest extends AnyFlatSpec with Matchers with ElapsedTime {
   behavior of "Source.throttle"
 
   it should "not throttle the empty source" in supervised {
@@ -36,10 +37,4 @@ class SourceOpsThrottleTest extends AnyFlatSpec with Matchers {
       s.throttle(1, 50.nanos)
     } should have message "requirement failed: per time must be >= 1 ms"
   }
-
-  private def measure[T](f: => T): (T, Duration) =
-    val before = System.currentTimeMillis()
-    val result = f
-    val after = System.currentTimeMillis();
-    (result, (after - before).millis)
 }

--- a/core/src/test/scala/ox/retry/BackoffRetryTest.scala
+++ b/core/src/test/scala/ox/retry/BackoffRetryTest.scala
@@ -23,7 +23,7 @@ class BackoffRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
       if true then throw new RuntimeException("boom")
 
     // when
-    val (result, elapsedTime) = measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.Backoff(maxRetries, initialDelay)))
+    val (result, elapsedTime) = measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.backoff(maxRetries, initialDelay)))
 
     // then
     result should have message "boom"
@@ -43,7 +43,7 @@ class BackoffRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
       if counter <= retriesUntilSuccess then throw new RuntimeException("boom") else successfulResult
 
     // when
-    val result = retry(f)(RetryPolicy.Backoff.forever(initialDelay, maxDelay = 2.millis))
+    val result = retry(f)(RetryPolicy.backoffForever(initialDelay, maxDelay = 2.millis))
 
     // then
     result shouldBe successfulResult
@@ -61,7 +61,7 @@ class BackoffRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
       if true then throw new RuntimeException("boom")
 
     // when
-    val (result, elapsedTime) = measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.Backoff(maxRetries, initialDelay, maxDelay)))
+    val (result, elapsedTime) = measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.backoff(maxRetries, initialDelay, maxDelay)))
 
     // then
     result should have message "boom"
@@ -82,7 +82,7 @@ class BackoffRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
 
     // when
     val (result, elapsedTime) =
-      measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.Backoff(maxRetries, initialDelay, maxDelay, Jitter.Equal)))
+      measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.backoff(maxRetries, initialDelay, maxDelay, Jitter.Equal)))
 
     // then
     result should have message "boom"
@@ -103,7 +103,7 @@ class BackoffRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
       Left(errorMessage)
 
     // when
-    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.Backoff(maxRetries, initialDelay)))
+    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.backoff(maxRetries, initialDelay)))
 
     // then
     result.left.value shouldBe errorMessage
@@ -123,7 +123,7 @@ class BackoffRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
       Failure(new RuntimeException(errorMessage))
 
     // when
-    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.Backoff(maxRetries, initialDelay)))
+    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.backoff(maxRetries, initialDelay)))
 
     // then
     result.failure.exception should have message errorMessage
@@ -132,4 +132,4 @@ class BackoffRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
   }
 
   private def expectedTotalBackoffTimeMillis(maxRetries: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration = 1.day): Long =
-    (0 until maxRetries).map(RetryPolicy.Backoff.delay(_, initialDelay, maxDelay).toMillis).sum
+    (0 until maxRetries).map(Schedule.Backoff.delay(_, initialDelay, maxDelay).toMillis).sum

--- a/core/src/test/scala/ox/retry/BackoffRetryTest.scala
+++ b/core/src/test/scala/ox/retry/BackoffRetryTest.scala
@@ -1,0 +1,75 @@
+package ox.retry
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{EitherValues, TryValues}
+import ox.ElapsedTime
+import ox.retry.*
+
+import scala.concurrent.duration.*
+import scala.util.Failure
+
+class BackoffRetryTest extends AnyFlatSpec with Matchers with EitherValues with TryValues with ElapsedTime:
+
+  behavior of "Backoff retry"
+
+  it should "retry a function" in {
+    // given
+    val maxRetries = 3
+    val sleep = 100.millis
+    var counter = 0
+    def f =
+      counter += 1
+      if true then throw new RuntimeException("boom")
+
+    // when
+    val (result, elapsedTime) = measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.Backoff(maxRetries, sleep)))
+
+    // then
+    result should have message "boom"
+    elapsedTime.toMillis should be >= expectedTotalBackoffTimeMillis(maxRetries, sleep)
+    counter shouldBe 4
+  }
+
+  it should "retry an Either" in {
+    // given
+    val maxRetries = 3
+    val sleep = 100.millis
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Left(errorMessage)
+
+    // when
+    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.Backoff(maxRetries, sleep)))
+
+    // then
+    result.left.value shouldBe errorMessage
+    elapsedTime.toMillis should be >= expectedTotalBackoffTimeMillis(maxRetries, sleep)
+    counter shouldBe 4
+  }
+
+  it should "retry a Try" in {
+    // given
+    val maxRetries = 3
+    val sleep = 100.millis
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Failure(new RuntimeException(errorMessage))
+
+    // when
+    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.Backoff(maxRetries, sleep)))
+
+    // then
+    result.failure.exception should have message errorMessage
+    elapsedTime.toMillis should be >= expectedTotalBackoffTimeMillis(maxRetries, sleep)
+    counter shouldBe 4
+  }
+
+  private def expectedTotalBackoffTimeMillis(maxRetries: Int, sleep: FiniteDuration): Long =
+    (0 until maxRetries).map(sleep.toMillis * Math.pow(2, _).toLong).sum

--- a/core/src/test/scala/ox/retry/BackoffRetryTest.scala
+++ b/core/src/test/scala/ox/retry/BackoffRetryTest.scala
@@ -31,6 +31,25 @@ class BackoffRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
     counter shouldBe 4
   }
 
+  it should "retry a failing function forever" in {
+    // given
+    var counter = 0
+    val initialDelay = 100.millis
+    val retriesUntilSuccess = 1_000
+    val successfulResult = 42
+
+    def f =
+      counter += 1
+      if counter <= retriesUntilSuccess then throw new RuntimeException("boom") else successfulResult
+
+    // when
+    val result = retry(f)(RetryPolicy.Backoff.forever(initialDelay, maxDelay = 2.millis))
+
+    // then
+    result shouldBe successfulResult
+    counter shouldBe retriesUntilSuccess + 1
+  }
+
   it should "respect maximum delay" in {
     // given
     val maxRetries = 3

--- a/core/src/test/scala/ox/retry/DelayedRetryTest.scala
+++ b/core/src/test/scala/ox/retry/DelayedRetryTest.scala
@@ -1,0 +1,72 @@
+package ox.retry
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{EitherValues, TryValues}
+import ox.ElapsedTime
+import ox.retry.*
+
+import scala.concurrent.duration.*
+import scala.util.Failure
+
+class DelayedRetryTest extends AnyFlatSpec with Matchers with EitherValues with TryValues with ElapsedTime:
+
+  behavior of "Delayed retry"
+
+  it should "retry a function" in {
+    // given
+    val maxRetries = 3
+    val sleep = 100.millis
+    var counter = 0
+    def f =
+      counter += 1
+      if true then throw new RuntimeException("boom")
+
+    // when
+    val (result, elapsedTime) = measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.Delay(maxRetries, sleep)))
+
+    // then
+    result should have message "boom"
+    elapsedTime.toMillis should be >= maxRetries * sleep.toMillis
+    counter shouldBe 4
+  }
+
+  it should "retry an Either" in {
+    // given
+    val maxRetries = 3
+    val sleep = 100.millis
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Left(errorMessage)
+
+    // when
+    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.Delay(maxRetries, sleep)))
+
+    // then
+    result.left.value shouldBe errorMessage
+    elapsedTime.toMillis should be >= maxRetries * sleep.toMillis
+    counter shouldBe 4
+  }
+
+  it should "retry a Try" in {
+    // given
+    val maxRetries = 3
+    val sleep = 100.millis
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Failure(new RuntimeException(errorMessage))
+
+    // when
+    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.Delay(maxRetries, sleep)))
+
+    // then
+    result.failure.exception should have message errorMessage
+    elapsedTime.toMillis should be >= maxRetries * sleep.toMillis
+    counter shouldBe 4
+  }

--- a/core/src/test/scala/ox/retry/DelayedRetryTest.scala
+++ b/core/src/test/scala/ox/retry/DelayedRetryTest.scala
@@ -23,7 +23,7 @@ class DelayedRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
       if true then throw new RuntimeException("boom")
 
     // when
-    val (result, elapsedTime) = measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.Delay(maxRetries, sleep)))
+    val (result, elapsedTime) = measure(the[RuntimeException] thrownBy retry(f)(RetryPolicy.delay(maxRetries, sleep)))
 
     // then
     result should have message "boom"
@@ -43,7 +43,7 @@ class DelayedRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
       if counter <= retriesUntilSuccess then throw new RuntimeException("boom") else successfulResult
 
     // when
-    val result = retry(f)(RetryPolicy.Delay.forever(sleep))
+    val result = retry(f)(RetryPolicy.delayForever(sleep))
 
     // then
     result shouldBe successfulResult
@@ -62,7 +62,7 @@ class DelayedRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
       Left(errorMessage)
 
     // when
-    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.Delay(maxRetries, sleep)))
+    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.delay(maxRetries, sleep)))
 
     // then
     result.left.value shouldBe errorMessage
@@ -82,7 +82,7 @@ class DelayedRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
       Failure(new RuntimeException(errorMessage))
 
     // when
-    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.Delay(maxRetries, sleep)))
+    val (result, elapsedTime) = measure(retry(f)(RetryPolicy.delay(maxRetries, sleep)))
 
     // then
     result.failure.exception should have message errorMessage

--- a/core/src/test/scala/ox/retry/DelayedRetryTest.scala
+++ b/core/src/test/scala/ox/retry/DelayedRetryTest.scala
@@ -31,6 +31,25 @@ class DelayedRetryTest extends AnyFlatSpec with Matchers with EitherValues with 
     counter shouldBe 4
   }
 
+  it should "retry a failing function forever" in {
+    // given
+    var counter = 0
+    val sleep = 2.millis
+    val retriesUntilSuccess = 1_000
+    val successfulResult = 42
+
+    def f =
+      counter += 1
+      if counter <= retriesUntilSuccess then throw new RuntimeException("boom") else successfulResult
+
+    // when
+    val result = retry(f)(RetryPolicy.Delay.forever(sleep))
+
+    // then
+    result shouldBe successfulResult
+    counter shouldBe retriesUntilSuccess + 1
+  }
+
   it should "retry an Either" in {
     // given
     val maxRetries = 3

--- a/core/src/test/scala/ox/retry/DirectRetryTest.scala
+++ b/core/src/test/scala/ox/retry/DirectRetryTest.scala
@@ -1,0 +1,161 @@
+package ox.retry
+
+import org.scalatest.{EitherValues, TryValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.retry.*
+
+import scala.util.{Failure, Success}
+
+class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with Matchers:
+
+  behavior of "Direct retry"
+
+  it should "retry a succeeding function" in {
+    // given
+    var counter = 0
+    val successfulResult = 42
+
+    def f =
+      counter += 1
+      successfulResult
+
+    // when
+    val result = retry(f)(RetryPolicy.Direct(3))
+
+    // then
+    result shouldBe successfulResult
+    counter shouldBe 1
+  }
+
+  it should "retry a succeeding function with a custom success condition" in {
+    // given
+    var counter = 0
+    val unsuccessfulResult = -1
+
+    def f =
+      counter += 1
+      unsuccessfulResult
+
+    // when
+    val result = retry(f, _ > 0)(RetryPolicy.Direct(3))
+
+    // then
+    result shouldBe unsuccessfulResult
+    counter shouldBe 4
+  }
+
+  it should "retry a failing function" in {
+    // given
+    var counter = 0
+
+    def f =
+      counter += 1
+      if true then throw new RuntimeException("boom")
+
+    // when/then
+    the[RuntimeException] thrownBy retry(f)(RetryPolicy.Direct(3)) should have message "boom"
+    counter shouldBe 4
+  }
+
+  it should "retry a succeeding Either" in {
+    // given
+    var counter = 0
+    val successfulResult = 42
+
+    def f: Either[String, Int] =
+      counter += 1
+      Right(successfulResult)
+
+    // when
+    val result = retry(f)(RetryPolicy.Direct(3))
+
+    // then
+    result.value shouldBe successfulResult
+    counter shouldBe 1
+  }
+
+  it should "retry a succeeding Either with a custom success condition" in {
+    // given
+    var counter = 0
+    val unsuccessfulResult = -1
+
+    def f: Either[String, Int] =
+      counter += 1
+      Right(unsuccessfulResult)
+
+    // when
+    val result = retry(f, (res: Int) => res > 0)(RetryPolicy.Direct(3))
+
+    // then
+    result.value shouldBe unsuccessfulResult
+    counter shouldBe 4
+  }
+
+  it should "retry a failing Either" in {
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Left(errorMessage)
+
+    // when
+    val result = retry(f)(RetryPolicy.Direct(3))
+
+    // then
+    result.left.value shouldBe errorMessage
+    counter shouldBe 4
+  }
+
+  it should "retry a succeeding Try" in {
+    // given
+    var counter = 0
+    val successfulResult = 42
+
+    def f =
+      counter += 1
+      Success(successfulResult)
+
+    // when
+    val result = retry(f, (res: Int) => res > 0)(RetryPolicy.Direct(3))
+
+    // then
+    result.success.value shouldBe successfulResult
+    counter shouldBe 1
+  }
+
+  it should "retry a succeeding Try with a custom success condition" in {
+    // given
+    var counter = 0
+    val unsuccessfulResult = -1
+
+    def f =
+      counter += 1
+      Success(unsuccessfulResult)
+
+    // when
+    val result = retry(f, (res: Int) => res > 0)(RetryPolicy.Direct(3))
+
+    // then
+    result.success.value shouldBe unsuccessfulResult
+    counter shouldBe 4
+  }
+
+  it should "retry a failing Try" in {
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Failure(new RuntimeException(errorMessage))
+
+    // when
+    val result = retry(f)(RetryPolicy.Direct(3))
+
+    // then
+    result.failure.exception should have message errorMessage
+    counter shouldBe 4
+  }

--- a/core/src/test/scala/ox/retry/DirectRetryTest.scala
+++ b/core/src/test/scala/ox/retry/DirectRetryTest.scala
@@ -21,7 +21,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       successfulResult
 
     // when
-    val result = retry(f)(RetryPolicy.Direct(3))
+    val result = retry(f)(RetryPolicy.direct(3))
 
     // then
     result shouldBe successfulResult
@@ -32,13 +32,14 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val errorMessage = "boom"
+    val policy = RetryPolicy[Throwable, Unit](Schedule.Direct(3), ResultPolicy.retryWhen(_ => false))
 
     def f =
       counter += 1
       if true then throw new RuntimeException(errorMessage)
 
     // when/then
-    the[RuntimeException] thrownBy retry(f, isWorthRetrying = _ => false)(RetryPolicy.Direct(3)) should have message errorMessage
+    the[RuntimeException] thrownBy retry(f)(policy) should have message errorMessage
     counter shouldBe 1
   }
 
@@ -46,13 +47,14 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val unsuccessfulResult = -1
+    val policy = RetryPolicy[Throwable, Int](Schedule.Direct(3), ResultPolicy.successfulWhen(_ > 0))
 
     def f =
       counter += 1
       unsuccessfulResult
 
     // when
-    val result = retry(f, isSuccess = _ > 0)(RetryPolicy.Direct(3))
+    val result = retry(f)(policy)
 
     // then
     result shouldBe unsuccessfulResult
@@ -69,7 +71,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       if true then throw new RuntimeException(errorMessage)
 
     // when/then
-    the[RuntimeException] thrownBy retry(f)(RetryPolicy.Direct(3)) should have message errorMessage
+    the[RuntimeException] thrownBy retry(f)(RetryPolicy.direct(3)) should have message errorMessage
     counter shouldBe 4
   }
 
@@ -84,7 +86,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       if counter <= retriesUntilSuccess then throw new RuntimeException("boom") else successfulResult
 
     // when
-    val result = retry(f)(RetryPolicy.Direct.forever)
+    val result = retry(f)(RetryPolicy.directForever)
 
     // then
     result shouldBe successfulResult
@@ -101,7 +103,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       Right(successfulResult)
 
     // when
-    val result = retry(f)(RetryPolicy.Direct(3))
+    val result = retry(f)(RetryPolicy.direct(3))
 
     // then
     result.value shouldBe successfulResult
@@ -112,13 +114,14 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val errorMessage = "boom"
+    val policy: RetryPolicy[String, Int] = RetryPolicy(Schedule.Direct(3), ResultPolicy.neverRetry)
 
     def f: Either[String, Int] =
       counter += 1
       Left(errorMessage)
 
     // when
-    val result = retry(f, isWorthRetrying = (_: String) => false)(RetryPolicy.Direct(3))
+    val result = retry(f)(policy)
 
     // then
     result.left.value shouldBe errorMessage
@@ -129,13 +132,14 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val unsuccessfulResult = -1
+    val policy: RetryPolicy[String, Int] = RetryPolicy(Schedule.Direct(3), ResultPolicy.successfulWhen(_ > 0))
 
     def f: Either[String, Int] =
       counter += 1
       Right(unsuccessfulResult)
 
     // when
-    val result = retry(f, isSuccess = (res: Int) => res > 0)(RetryPolicy.Direct(3))
+    val result = retry(f)(policy)
 
     // then
     result.value shouldBe unsuccessfulResult
@@ -152,7 +156,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       Left(errorMessage)
 
     // when
-    val result = retry(f)(RetryPolicy.Direct(3))
+    val result = retry(f)(RetryPolicy.direct(3))
 
     // then
     result.left.value shouldBe errorMessage
@@ -169,7 +173,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       Success(successfulResult)
 
     // when
-    val result = retry(f)(RetryPolicy.Direct(3))
+    val result = retry(f)(RetryPolicy.direct(3))
 
     // then
     result.success.value shouldBe successfulResult
@@ -180,13 +184,14 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val errorMessage = "boom"
+    val policy: RetryPolicy[Throwable, Int] = RetryPolicy(Schedule.Direct(3), ResultPolicy.neverRetry)
 
     def f =
       counter += 1
       Failure(new RuntimeException(errorMessage))
 
     // when
-    val result = retry(f, isWorthRetrying = (_: Throwable) => false)(RetryPolicy.Direct(3))
+    val result = retry(f)(policy)
 
     // then
     result.failure.exception should have message errorMessage
@@ -197,13 +202,14 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val unsuccessfulResult = -1
+    val policy: RetryPolicy[Throwable, Int] = RetryPolicy(Schedule.Direct(3), ResultPolicy.successfulWhen(_ > 0))
 
     def f =
       counter += 1
       Success(unsuccessfulResult)
 
     // when
-    val result = retry(f, isSuccess = (res: Int) => res > 0)(RetryPolicy.Direct(3))
+    val result = retry(f)(policy)
 
     // then
     result.success.value shouldBe unsuccessfulResult
@@ -220,7 +226,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       Failure(new RuntimeException(errorMessage))
 
     // when
-    val result = retry(f)(RetryPolicy.Direct(3))
+    val result = retry(f)(RetryPolicy.direct(3))
 
     // then
     result.failure.exception should have message errorMessage

--- a/core/src/test/scala/ox/retry/DirectRetryTest.scala
+++ b/core/src/test/scala/ox/retry/DirectRetryTest.scala
@@ -75,6 +75,23 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     counter shouldBe 1
   }
 
+  it should "fail fast when an Either is not worth retrying" in {
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f: Either[String, Int] =
+      counter += 1
+      Left(errorMessage)
+
+    // when
+    val result = retry(f, _ => true, _ => false)(RetryPolicy.Direct(3))
+
+    // then
+    result.left.value shouldBe errorMessage
+    counter shouldBe 1
+  }
+
   it should "retry a succeeding Either with a custom success condition" in {
     // given
     var counter = 0

--- a/core/src/test/scala/ox/retry/DirectRetryTest.scala
+++ b/core/src/test/scala/ox/retry/DirectRetryTest.scala
@@ -58,6 +58,24 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     counter shouldBe 4
   }
 
+  it should "retry a failing function forever" in {
+    // given
+    var counter = 0
+    val retriesUntilSuccess = 10_000
+    val successfulResult = 42
+
+    def f =
+      counter += 1
+      if counter <= retriesUntilSuccess then throw new RuntimeException("boom") else successfulResult
+
+    // when
+    val result = retry(f)(RetryPolicy.Direct.forever)
+
+    // then
+    result shouldBe successfulResult
+    counter shouldBe retriesUntilSuccess + 1
+  }
+
   it should "retry a succeeding Either" in {
     // given
     var counter = 0

--- a/core/src/test/scala/ox/retry/ImmediateRetryTest.scala
+++ b/core/src/test/scala/ox/retry/ImmediateRetryTest.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success}
 
 class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues with Matchers:
 
-  behavior of "Direct retry"
+  behavior of "Immediate retry"
 
   it should "retry a succeeding function" in {
     // given

--- a/core/src/test/scala/ox/retry/ImmediateRetryTest.scala
+++ b/core/src/test/scala/ox/retry/ImmediateRetryTest.scala
@@ -7,7 +7,7 @@ import ox.retry.*
 
 import scala.util.{Failure, Success}
 
-class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with Matchers:
+class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues with Matchers:
 
   behavior of "Direct retry"
 
@@ -21,7 +21,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       successfulResult
 
     // when
-    val result = retry(f)(RetryPolicy.direct(3))
+    val result = retry(f)(RetryPolicy.immediate(3))
 
     // then
     result shouldBe successfulResult
@@ -32,7 +32,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val errorMessage = "boom"
-    val policy = RetryPolicy[Throwable, Unit](Schedule.Direct(3), ResultPolicy.retryWhen(_ => false))
+    val policy = RetryPolicy[Throwable, Unit](Schedule.Immediate(3), ResultPolicy.retryWhen(_ => false))
 
     def f =
       counter += 1
@@ -47,7 +47,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val unsuccessfulResult = -1
-    val policy = RetryPolicy[Throwable, Int](Schedule.Direct(3), ResultPolicy.successfulWhen(_ > 0))
+    val policy = RetryPolicy[Throwable, Int](Schedule.Immediate(3), ResultPolicy.successfulWhen(_ > 0))
 
     def f =
       counter += 1
@@ -71,7 +71,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       if true then throw new RuntimeException(errorMessage)
 
     // when/then
-    the[RuntimeException] thrownBy retry(f)(RetryPolicy.direct(3)) should have message errorMessage
+    the[RuntimeException] thrownBy retry(f)(RetryPolicy.immediate(3)) should have message errorMessage
     counter shouldBe 4
   }
 
@@ -86,7 +86,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       if counter <= retriesUntilSuccess then throw new RuntimeException("boom") else successfulResult
 
     // when
-    val result = retry(f)(RetryPolicy.directForever)
+    val result = retry(f)(RetryPolicy.immediateForever)
 
     // then
     result shouldBe successfulResult
@@ -103,7 +103,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       Right(successfulResult)
 
     // when
-    val result = retry(f)(RetryPolicy.direct(3))
+    val result = retry(f)(RetryPolicy.immediate(3))
 
     // then
     result.value shouldBe successfulResult
@@ -114,7 +114,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val errorMessage = "boom"
-    val policy: RetryPolicy[String, Int] = RetryPolicy(Schedule.Direct(3), ResultPolicy.neverRetry)
+    val policy: RetryPolicy[String, Int] = RetryPolicy(Schedule.Immediate(3), ResultPolicy.neverRetry)
 
     def f: Either[String, Int] =
       counter += 1
@@ -132,7 +132,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val unsuccessfulResult = -1
-    val policy: RetryPolicy[String, Int] = RetryPolicy(Schedule.Direct(3), ResultPolicy.successfulWhen(_ > 0))
+    val policy: RetryPolicy[String, Int] = RetryPolicy(Schedule.Immediate(3), ResultPolicy.successfulWhen(_ > 0))
 
     def f: Either[String, Int] =
       counter += 1
@@ -156,7 +156,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       Left(errorMessage)
 
     // when
-    val result = retry(f)(RetryPolicy.direct(3))
+    val result = retry(f)(RetryPolicy.immediate(3))
 
     // then
     result.left.value shouldBe errorMessage
@@ -173,7 +173,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       Success(successfulResult)
 
     // when
-    val result = retry(f)(RetryPolicy.direct(3))
+    val result = retry(f)(RetryPolicy.immediate(3))
 
     // then
     result.success.value shouldBe successfulResult
@@ -184,7 +184,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val errorMessage = "boom"
-    val policy: RetryPolicy[Throwable, Int] = RetryPolicy(Schedule.Direct(3), ResultPolicy.neverRetry)
+    val policy: RetryPolicy[Throwable, Int] = RetryPolicy(Schedule.Immediate(3), ResultPolicy.neverRetry)
 
     def f =
       counter += 1
@@ -202,7 +202,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
     // given
     var counter = 0
     val unsuccessfulResult = -1
-    val policy: RetryPolicy[Throwable, Int] = RetryPolicy(Schedule.Direct(3), ResultPolicy.successfulWhen(_ > 0))
+    val policy: RetryPolicy[Throwable, Int] = RetryPolicy(Schedule.Immediate(3), ResultPolicy.successfulWhen(_ > 0))
 
     def f =
       counter += 1
@@ -226,7 +226,7 @@ class DirectRetryTest extends AnyFlatSpec with EitherValues with TryValues with 
       Failure(new RuntimeException(errorMessage))
 
     // when
-    val result = retry(f)(RetryPolicy.direct(3))
+    val result = retry(f)(RetryPolicy.immediate(3))
 
     // then
     result.failure.exception should have message errorMessage

--- a/core/src/test/scala/ox/retry/ImmediateRetryTest.scala
+++ b/core/src/test/scala/ox/retry/ImmediateRetryTest.scala
@@ -32,7 +32,7 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
     // given
     var counter = 0
     val errorMessage = "boom"
-    val policy = RetryPolicy[Throwable, Unit](Schedule.Immediate(3), ResultPolicy.retryWhen(_ => false))
+    val policy = RetryPolicy[Throwable, Unit](Schedule.Immediate(3), ResultPolicy.retryWhen(_.getMessage != errorMessage))
 
     def f =
       counter += 1
@@ -114,7 +114,7 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
     // given
     var counter = 0
     val errorMessage = "boom"
-    val policy: RetryPolicy[String, Int] = RetryPolicy(Schedule.Immediate(3), ResultPolicy.neverRetry)
+    val policy: RetryPolicy[String, Int] = RetryPolicy(Schedule.Immediate(3), ResultPolicy.retryWhen(_ != errorMessage))
 
     def f: Either[String, Int] =
       counter += 1

--- a/core/src/test/scala/ox/retry/JitterTest.scala
+++ b/core/src/test/scala/ox/retry/JitterTest.scala
@@ -62,7 +62,7 @@ class JitterTest extends AnyFlatSpec with Matchers {
     Inspectors.forEvery(delays.sliding(2).toList) {
       case Seq(previousDelay, delay) =>
         delay should (be >= policy.initialDelay and be <= previousDelay * 3)
-      case _ => succeed // so that the match is exhaustive
+      case _ => fail("should never happen") // so that the match is exhaustive
     }
   }
 }

--- a/core/src/test/scala/ox/retry/JitterTest.scala
+++ b/core/src/test/scala/ox/retry/JitterTest.scala
@@ -1,0 +1,68 @@
+package ox.retry
+
+import org.scalatest.Inspectors
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.*
+
+class JitterTest extends AnyFlatSpec with Matchers {
+
+  behavior of "Jitter"
+
+  private val basePolicy = RetryPolicy.Backoff(maxRetries = 3, initialDelay = 100.millis)
+
+  it should "use no jitter" in {
+    // given
+    val policy = basePolicy
+
+    // when
+    val delays = (1 to 5).map(policy.nextDelay(_, None))
+
+    // then
+    delays should contain theSameElementsInOrderAs Seq(200, 400, 800, 1600, 3200).map(_.millis)
+  }
+
+  it should "use full jitter" in {
+    // given
+    val policy = basePolicy.copy(jitter = Jitter.Full)
+
+    // when
+    val delays = (1 to 5).map(policy.nextDelay(_, None))
+
+    // then
+    Inspectors.forEvery(delays.zipWithIndex) { case (delay, i) =>
+      val backoffDelay = RetryPolicy.Backoff.delay(i + 1, policy.initialDelay, policy.maxDelay)
+      delay should (be >= 0.millis and be <= backoffDelay)
+    }
+  }
+
+  it should "use equal jitter" in {
+    // given
+    val policy = basePolicy.copy(jitter = Jitter.Equal)
+
+    // when
+    val delays = (1 to 5).map(policy.nextDelay(_, None))
+
+    // then
+    Inspectors.forEvery(delays.zipWithIndex) { case (delay, i) =>
+      val backoffDelay = RetryPolicy.Backoff.delay(i + 1, policy.initialDelay, policy.maxDelay)
+      delay should (be >= backoffDelay / 2 and be <= backoffDelay)
+    }
+  }
+
+  it should "use decorrelated jitter" in {
+    // given
+    val policy = basePolicy.copy(jitter = Jitter.Decorrelated)
+
+    // when
+    val delays = (1 to 5).map(policy.nextDelay(_, None))
+
+    // then
+    Inspectors.forEvery(delays.sliding(2).map(_.toList).toList) {
+      case List(previousDelay, delay) =>
+        delay should (be >= policy.initialDelay and be <= previousDelay * 3)
+      case _ => succeed // so that the match is exhaustive
+    }
+  }
+}

--- a/core/src/test/scala/ox/retry/JitterTest.scala
+++ b/core/src/test/scala/ox/retry/JitterTest.scala
@@ -10,14 +10,14 @@ class JitterTest extends AnyFlatSpec with Matchers {
 
   behavior of "Jitter"
 
-  private val basePolicy = RetryPolicy.Backoff(maxRetries = 3, initialDelay = 100.millis)
+  private val baseSchedule = Schedule.Backoff(maxRetries = 3, initialDelay = 100.millis)
 
   it should "use no jitter" in {
     // given
-    val policy = basePolicy
+    val schedule = baseSchedule
 
     // when
-    val delays = (1 to 5).map(policy.nextDelay(_, None))
+    val delays = (1 to 5).map(schedule.nextDelay(_, None))
 
     // then
     delays should contain theSameElementsInOrderAs Seq(200, 400, 800, 1600, 3200).map(_.millis)
@@ -25,43 +25,43 @@ class JitterTest extends AnyFlatSpec with Matchers {
 
   it should "use full jitter" in {
     // given
-    val policy = basePolicy.copy(jitter = Jitter.Full)
+    val schedule = baseSchedule.copy(jitter = Jitter.Full)
 
     // when
-    val delays = (1 to 5).map(policy.nextDelay(_, None))
+    val delays = (1 to 5).map(schedule.nextDelay(_, None))
 
     // then
     Inspectors.forEvery(delays.zipWithIndex) { case (delay, i) =>
-      val backoffDelay = RetryPolicy.Backoff.delay(i + 1, policy.initialDelay, policy.maxDelay)
+      val backoffDelay = Schedule.Backoff.delay(i + 1, schedule.initialDelay, schedule.maxDelay)
       delay should (be >= 0.millis and be <= backoffDelay)
     }
   }
 
   it should "use equal jitter" in {
     // given
-    val policy = basePolicy.copy(jitter = Jitter.Equal)
+    val schedule = baseSchedule.copy(jitter = Jitter.Equal)
 
     // when
-    val delays = (1 to 5).map(policy.nextDelay(_, None))
+    val delays = (1 to 5).map(schedule.nextDelay(_, None))
 
     // then
     Inspectors.forEvery(delays.zipWithIndex) { case (delay, i) =>
-      val backoffDelay = RetryPolicy.Backoff.delay(i + 1, policy.initialDelay, policy.maxDelay)
+      val backoffDelay = Schedule.Backoff.delay(i + 1, schedule.initialDelay, schedule.maxDelay)
       delay should (be >= backoffDelay / 2 and be <= backoffDelay)
     }
   }
 
   it should "use decorrelated jitter" in {
     // given
-    val policy = basePolicy.copy(jitter = Jitter.Decorrelated)
+    val schedule = baseSchedule.copy(jitter = Jitter.Decorrelated)
 
     // when
-    val delays = (1 to 5).map(policy.nextDelay(_, None))
+    val delays = (1 to 5).map(schedule.nextDelay(_, None))
 
     // then
     Inspectors.forEvery(delays.sliding(2).toList) {
       case Seq(previousDelay, delay) =>
-        delay should (be >= policy.initialDelay and be <= previousDelay * 3)
+        delay should (be >= schedule.initialDelay and be <= previousDelay * 3)
       case _ => fail("should never happen") // so that the match is exhaustive
     }
   }

--- a/core/src/test/scala/ox/retry/JitterTest.scala
+++ b/core/src/test/scala/ox/retry/JitterTest.scala
@@ -59,8 +59,8 @@ class JitterTest extends AnyFlatSpec with Matchers {
     val delays = (1 to 5).map(policy.nextDelay(_, None))
 
     // then
-    Inspectors.forEvery(delays.sliding(2).map(_.toList).toList) {
-      case List(previousDelay, delay) =>
+    Inspectors.forEvery(delays.sliding(2).toList) {
+      case Seq(previousDelay, delay) =>
         delay should (be >= policy.initialDelay and be <= previousDelay * 3)
       case _ => succeed // so that the match is exhaustive
     }

--- a/core/src/test/scala/ox/retry/RetrySyntaxTest.scala
+++ b/core/src/test/scala/ox/retry/RetrySyntaxTest.scala
@@ -1,0 +1,60 @@
+package ox.retry
+
+import org.scalatest.{EitherValues, TryValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.syntax.*
+
+import scala.util.Failure
+
+class RetrySyntaxTest extends AnyFlatSpec with Matchers with TryValues with EitherValues:
+
+  behavior of "Retry syntax"
+
+  it should "support operations that return a result directly" in {
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      if true then throw new RuntimeException(errorMessage)
+
+    // when/then
+    the[RuntimeException] thrownBy f.retry(RetryPolicy.immediate(3)) should have message errorMessage
+    counter shouldBe 4
+  }
+
+  it should "support operations that return a Try" in {
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Failure(new RuntimeException(errorMessage))
+
+    // when
+    val result = f.retry(RetryPolicy.immediate(3))
+
+    // then
+    result.failure.exception should have message errorMessage
+    counter shouldBe 4
+  }
+
+  it should "support operations that return an Either" in {
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Left(errorMessage)
+
+    // when
+    val result = f.retry(RetryPolicy.immediate(3))
+
+    // then
+    result.left.value shouldBe errorMessage
+    counter shouldBe 4
+  }

--- a/doc/adr/0002-retries.md
+++ b/doc/adr/0002-retries.md
@@ -1,0 +1,22 @@
+# 2. Retries
+
+Date: 2023-11-30
+
+## Context
+
+How should the [retries API](../retries.md) be implemented in terms of:
+- developer friendliness,
+- supported ways of representing the operation under retry,
+- possibly infinite retries.
+
+## Decision
+
+We're using a single, unified syntax to retry and operation:
+```scala
+retry(operation)(policy)
+```
+so that the developers don't need to wonder which variant to use.
+
+The operation can be a function returning a result directly, or wrapped in a `Try` or `Either`. Therefore, there are three overloaded variants of the `retry` function.
+
+For possibly infinite retries, we're using tail recursion to be stack safe. This comes at a cost of some code duplication in the retry logic, but is still more readable and easier to follow that a `while` loop with `var`s for passing the state.

--- a/doc/retries.md
+++ b/doc/retries.md
@@ -39,7 +39,9 @@ The supported schedules (specifically - their finite variants) are:
 - `Delay(maxRetries: Int, delay: FiniteDuration)` - retries up to `maxRetries` times , sleeping for `delay` between subsequent attempts.
 - `Backoff(maxRetries: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration, jitter: Jitter)` - retries up to `maxRetries` times , sleeping for `initialDelay` before the first retry, increasing the sleep between subsequent attempts exponentially (with base `2`) up to an optional `maxDelay` (default: 1 minute). 
 
-  Optionally, a random factor (jitter) can be used when calculating the delay before the next attempt. The purpose of jitter is to avoid clustering of subsequent retries, i.e. to reduce the number of clients calling a service exactly at the same time. See the [AWS Architecture Blog article on backoff and jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) for a more in-depth explanation. 
+  Optionally, a random factor (jitter) can be used when calculating the delay before the next attempt. The purpose of jitter is to avoid clustering of subsequent retries, i.e. to reduce the number of clients calling a service exactly at the same time, which can result in subsequent failures, contrary to what you would expect from retrying. By introducing randomness to the delays, the retries become more evenly distributed over time. 
+- 
+- See the [AWS Architecture Blog article on backoff and jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) for a more in-depth explanation. 
 
   The following jitter strategies are available (defined in the `Jitter` enum):
   - `None` - the default one, when no randomness is added, i.e. a pure exponential backoff is used,

--- a/doc/retries.md
+++ b/doc/retries.md
@@ -1,0 +1,107 @@
+# Retries
+
+The retries mechanism allows to retry a failing operation according to a given policy (e.g. retry 3 times with a 100ms delay between attempts).
+
+## API
+The basic syntax for retries is:
+```scala
+retry[T](operation)(policy)
+```
+
+## Operation definition
+The `operation` can be provided as one of:
+- a direct by-name parameter, i.e. `f: => T`
+- a by-name `Try[T]`, i.e. `f: => Try[T]`
+- a by-name `Either[E, T]`, i.e. `f: => Either[E, T]`
+
+## Policies
+
+A retry policy consists of two parts:
+- a `Schedule`, which indicates how many times and with what delay should we retry the `operation` after an initial failure,
+- a `ResultPolicy`, which indicates whether:
+  - a non-erroneous outcome of the `operation` should be considered a success (if not, the `operation` would be retried),
+  - an erroneous outcome of the `operation` should be retried or fail fast.
+
+The available schedules are defined in the `Schedule` object. Each schedule has a finite and an infinite variant.
+
+### Finite schedules
+
+Finite schedules have a common `maxRetries: Int` parameter, which determines how many times the `operation` would be retried after an initial failure. This means that the operation could be executed at most `maxRetries + 1` times. 
+
+### Infinite schedules
+
+Each finite schedule has an infinite variant, whose settings are similar to those of the respective finite schedule, but without the `maxRetries` setting. Using the infinite variant can lead to a possibly infinite number of retries (unless the `operation` starts to succeed again at some point). The infinite schedules are created by calling `.forever` on the companion object of the respective finite schedule (see examples below).
+
+### Schedule types
+
+The supported schedules (specifically - their finite variants) are:
+- `Immediate(maxRetries: Int)` - retries up to `maxRetries` times without any delay between subsequent attempts.
+- `Delay(maxRetries: Int, delay: FiniteDuration)` - retries up to `maxRetries` times , sleeping for `delay` between subsequent attempts.
+- `Backoff(maxRetries: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration, jitter: Jitter)` - retries up to `maxRetries` times , sleeping for `initialDelay` before the first retry, increasing the sleep between subsequent attempts exponentially (with base `2`) up to an optional `maxDelay` (default: 1 minute). 
+
+  Optionally, a random factor (jitter) can be used when calculating the delay before the next attempt. The purpose of jitter is to avoid clustering of subsequent retries, i.e. to reduce the number of clients calling a service exactly at the same time. See the [AWS Architecture Blog article on backoff and jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) for a more in-depth explanation. 
+
+  The following jitter strategies are available (defined in the `Jitter` enum):
+  - `None` - the default one, when no randomness is added, i.e. a pure exponential backoff is used,
+  - `Full` - picks a random value between `0` and the exponential backoff calculated for the current attempt,
+  - `Equal` - similar to `Full`, but prevents very short delays by always using a half of the original backoff and adding a random value between `0` and the other half,
+  - `Decorrelated` - uses the delay from the previous attempt (`lastDelay`) and picks a random value between the `initalAttempt` and `3 * lastDelay`.
+
+### Result policies
+
+A result policy allows to customize how the results of the `operation` are treated. It consists of two predicates:
+- `isSuccess: T => Boolean` (default: `true`) - determines whether a non-erroneous result of the `operation` should be considered a success. When it evaluates to `true` - no further attempts would be made, otherwise - we'd keep retrying.
+
+  With finite schedules (i.e. those with `maxRetries` defined), if `isSuccess` keeps returning `false` when `maxRetries` are reached, the result is returned as-is, even though it's considered "unsuccessful",
+- `isWorthRetrying: E => Boolean` (default: `true`) - determines whether another attempt would be made if the `operation` results in an error `E`. When it evaluates to `true` - we'd keep retrying, otherwise - we'd fail fast with the error.
+
+The `ResultPolicy[E, T]` is generic both over the error (`E`) and result (`T`) type. For the direct and `Try` variants of the `operation`, you would typically use `Throwable` for `E`, while for the `Either` variant, `E` can ba an arbitrary type.
+
+### API shorthands
+
+When you don't need to customize the result policy (i.e. use the default one), you can use one of the following shorthands to define a retry policy with a given schedule (note that the parameters are the same as when manually creating the respective `Schedule`):
+- `RetryPolicy.immediate(maxRetries: Int)`,
+- `RetryPolicy.immediateForever`,
+- `RetryPolicy.delay(maxRetries: Int, delay: FiniteDuration)`,
+- `RetryPolicy.delayForever(delay: FiniteDuration)`,
+- `RetryPolicy.backoff(maxRetries: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration, jitter: Jitter)`,
+- `RetryPolicy.backoffForever(initialDelay: FiniteDuration, maxDelay: FiniteDuration, jitter: Jitter)`.
+
+If you want to customize a part of the result policy, you can use the following shorthands:
+- `ResultPolicy.default[E, T]` - uses the default settings,
+- `ResultPolicy.successfulWhen[E, T](isSuccess: T => Boolean)` - uses the default `isWorthRetrying` and the provided `isSuccess`,
+- `ResultPolicy.retryWhen[E, T](isWorthRetrying: E => Boolean)` - uses the default `isSuccess` and the provided `isWorthRetrying`,
+- `ResultPolicy.neverRetry[E, T]` - uses the default `isSuccess` and fails fast on any error.
+
+## Examples
+```scala
+import ox.retry
+import scala.concurrent.duration.*
+
+def directOperation: Int = ???
+def eitherOperation: Either[String, Int] = ???
+def tryOperation: Try[Int] = ???
+
+// various operation definitions - same syntax
+retry(directOperation)(RetryPolicy.immediate(3))
+retry(eitherOperation)(RetryPolicy.immediate(3))
+retry(tryOperation)(RetryPolicy.immediate(3))
+
+// various policies with custom schedules and default ResultPolicy
+retry(directOperation)(RetryPolicy.delay(3, 100.millis))
+retry(directOperation)(RetryPolicy.backoff(3, 100.millis)) // defaults: maxDelay = 1.minute, jitter = Jitter.None
+retry(directOperation)(RetryPolicy.backoff(3, 100.millis, 5.minutes, Jitter.Equal))
+
+// infinite retries with a default ResultPolicy
+retry(directOperation)(RetryPolicy.delayForever(100.millis))
+retry(directOperation)(RetryPolicy.backoffForever(100.millis, 5.minutes, Jitter.Full))
+
+// result policies
+// custom success
+retry(directOperation)(RetryPolicy(Schedule.Immediate(3), ResultPolicy.successfulWhen(_ > 0)))
+// fail fast on certain errors
+retry(directOperation)(RetryPolicy(Schedule.Immediate(3), ResultPolicy.retryWhen(_.getMessage != "fatal error")))
+retry(eitherOperation)(RetryPolicy(Schedule.Immediate(3), ResultPolicy.retryWhen(_ != "fatal error"))(3))
+```
+
+See the tests in `ox.retry.*` for more.

--- a/doc/retries.md
+++ b/doc/retries.md
@@ -55,7 +55,7 @@ A result policy allows to customize how the results of the `operation` are treat
   With finite schedules (i.e. those with `maxRetries` defined), if `isSuccess` keeps returning `false` when `maxRetries` are reached, the result is returned as-is, even though it's considered "unsuccessful",
 - `isWorthRetrying: E => Boolean` (default: `true`) - determines whether another attempt would be made if the `operation` results in an error `E`. When it evaluates to `true` - we'd keep retrying, otherwise - we'd fail fast with the error.
 
-The `ResultPolicy[E, T]` is generic both over the error (`E`) and result (`T`) type. Note, however, that For the direct and `Try` variants of the `operation`, the error type `E` is fixed to `Throwable`, while for the `Either` variant, `E` can ba an arbitrary type.
+The `ResultPolicy[E, T]` is generic both over the error (`E`) and result (`T`) type. Note, however, that for the direct and `Try` variants of the `operation`, the error type `E` is fixed to `Throwable`, while for the `Either` variant, `E` can ba an arbitrary type.
 
 ### API shorthands
 

--- a/doc/retries.md
+++ b/doc/retries.md
@@ -55,7 +55,7 @@ A result policy allows to customize how the results of the `operation` are treat
   With finite schedules (i.e. those with `maxRetries` defined), if `isSuccess` keeps returning `false` when `maxRetries` are reached, the result is returned as-is, even though it's considered "unsuccessful",
 - `isWorthRetrying: E => Boolean` (default: `true`) - determines whether another attempt would be made if the `operation` results in an error `E`. When it evaluates to `true` - we'd keep retrying, otherwise - we'd fail fast with the error.
 
-The `ResultPolicy[E, T]` is generic both over the error (`E`) and result (`T`) type. For the direct and `Try` variants of the `operation`, you would typically use `Throwable` for `E`, while for the `Either` variant, `E` can ba an arbitrary type.
+The `ResultPolicy[E, T]` is generic both over the error (`E`) and result (`T`) type. Note, however, that For the direct and `Try` variants of the `operation`, the error type `E` is fixed to `Throwable`, while for the `Either` variant, `E` can ba an arbitrary type.
 
 ### API shorthands
 

--- a/doc/retries.md
+++ b/doc/retries.md
@@ -5,7 +5,14 @@ The retries mechanism allows to retry a failing operation according to a given p
 ## API
 The basic syntax for retries is:
 ```scala
-retry[T](operation)(policy)
+retry(operation)(policy)
+```
+
+or, using a syntax sugar:
+```scala
+import ox.syntax.*
+
+operation.retry(policy)
 ```
 
 ## Operation definition


### PR DESCRIPTION
# Retries

Inspired by https://github.com/softwaremill/retry

## Rationale
The goal was to have a unified API (a single `retry` function) that would handle different ways of defining the operation (direct result, `Try` and `Either`), using various policies of delaying subsequent attempts (no delay, fixed delay, exponential backoff with an optional jitter), with a possibility to customize the definition of a successful result, and to fail fast on certain errors.

## API
The basic syntax for retries is:
```scala
retry[T](operation)(policy)
```

## Operation definition
The `operation` can be provided as one of:
- a direct by-name parameter, i.e. `f: => T`
- a by-name `Try[T]`, i.e. `f: => Try[T]`
- a by-name `Either[E, T]`, i.e. `f: => Either[E, T]`

## Policies

A retry policy consists of two parts:
- a `Schedule`, which indicates how many times and with what delay should we retry the `operation` after an initial failure,
- a `ResultPolicy`, which indicates whether:
  - a non-erroneous outcome of the `operation` should be considered a success (if not, the `operation` would be retried),
  - an erroneous outcome of the `operation` should be retried or fail fast.

The available schedules are defined in the `Schedule` object. Each schedule has a finite and an infinite variant.

### Finite schedules

Finite schedules have a common `maxRetries: Int` parameter, which determines how many times the `operation` would be retried after an initial failure. This means that the operation could be executed at most `maxRetries + 1` times. 

### Infinite schedules

Each finite schedule has an infinite variant, whose settings are similar to those of the respective finite schedule, but without the `maxRetries` setting. Using the infinite variant can lead to a possibly infinite number of retries (unless the `operation` starts to succeed again at some point). The infinite schedules are created by calling `.forever` on the companion object of the respective finite schedule (see examples below).

### Schedule types

The supported schedules (specifically - their finite variants) are:
- `Immediate(maxRetries: Int)` - retries up to `maxRetries` times without any delay between subsequent attempts.
- `Delay(maxRetries: Int, delay: FiniteDuration)` - retries up to `maxRetries` times , sleeping for `delay` between subsequent attempts.
- `Backoff(maxRetries: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration, jitter: Jitter)` - retries up to `maxRetries` times , sleeping for `initialDelay` before the first retry, increasing the sleep between subsequent attempts exponentially (with base `2`) up to an optional `maxDelay` (default: 1 minute). 

  Optionally, a random factor (jitter) can be used when calculating the delay before the next attempt. The purpose of jitter is to avoid clustering of subsequent retries, i.e. to reduce the number of clients calling a service exactly at the same time. See the [AWS Architecture Blog article on backoff and jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) for a more in-depth explanation. 

  The following jitter strategies are available (defined in the `Jitter` enum):
  - `None` - the default one, when no randomness is added, i.e. a pure exponential backoff is used,
  - `Full` - picks a random value between `0` and the exponential backoff calculated for the current attempt,
  - `Equal` - similar to `Full`, but prevents very short delays by always using a half of the original backoff and adding a random value between `0` and the other half,
  - `Decorrelated` - uses the delay from the previous attempt (`lastDelay`) and picks a random value between the `initalAttempt` and `3 * lastDelay`.

### Result policies

A result policy allows to customize how the results of the `operation` are treated. It consists of two predicates:
- `isSuccess: T => Boolean` (default: `true`) - determines whether a non-erroneous result of the `operation` should be considered a success. When it evaluates to `true` - no further attempts would be made, otherwise - we'd keep retrying.

  With finite schedules (i.e. those with `maxRetries` defined), if `isSuccess` keeps returning `false` when `maxRetries` are reached, the result is returned as-is, even though it's considered "unsuccessful",
- `isWorthRetrying: E => Boolean` (default: `true`) - determines whether another attempt would be made if the `operation` results in an error `E`. When it evaluates to `true` - we'd keep retrying, otherwise - we'd fail fast with the error.

The `ResultPolicy[E, T]` is generic both over the error (`E`) and result (`T`) type. Note, however, that for the direct and `Try` variants of the `operation`, the error type `E` is fixed to `Throwable`, while for the `Either` variant, `E` can ba an arbitrary type.

### API shorthands

When you don't need to customize the result policy (i.e. use the default one), you can use one of the following shorthands to define a retry policy with a given schedule (note that the parameters are the same as when manually creating the respective `Schedule`):
- `RetryPolicy.immediate(maxRetries: Int)`,
- `RetryPolicy.immediateForever`,
- `RetryPolicy.delay(maxRetries: Int, delay: FiniteDuration)`,
- `RetryPolicy.delayForever(delay: FiniteDuration)`,
- `RetryPolicy.backoff(maxRetries: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration, jitter: Jitter)`,
- `RetryPolicy.backoffForever(initialDelay: FiniteDuration, maxDelay: FiniteDuration, jitter: Jitter)`.

If you want to customize a part of the result policy, you can use the following shorthands:
- `ResultPolicy.default[E, T]` - uses the default settings,
- `ResultPolicy.successfulWhen[E, T](isSuccess: T => Boolean)` - uses the default `isWorthRetrying` and the provided `isSuccess`,
- `ResultPolicy.retryWhen[E, T](isWorthRetrying: E => Boolean)` - uses the default `isSuccess` and the provided `isWorthRetrying`,
- `ResultPolicy.neverRetry[E, T]` - uses the default `isSuccess` and fails fast on any error.

## Examples
```scala
import ox.retry
import scala.concurrent.duration.*

def directOperation: Int = ???
def eitherOperation: Either[String, Int] = ???
def tryOperation: Try[Int] = ???

// various operation definitions - same syntax
retry(directOperation)(RetryPolicy.immediate(3))
retry(eitherOperation)(RetryPolicy.immediate(3))
retry(tryOperation)(RetryPolicy.immediate(3))

// various policies with custom schedules and default ResultPolicy
retry(directOperation)(RetryPolicy.delay(3, 100.millis))
retry(directOperation)(RetryPolicy.backoff(3, 100.millis)) // defaults: maxDelay = 1.minute, jitter = Jitter.None
retry(directOperation)(RetryPolicy.backoff(3, 100.millis, 5.minutes, Jitter.Equal))

// infinite retries with a default ResultPolicy
retry(directOperation)(RetryPolicy.delayForever(100.millis))
retry(directOperation)(RetryPolicy.backoffForever(100.millis, 5.minutes, Jitter.Full))

// result policies
// custom success
retry(directOperation)(RetryPolicy(Schedule.Immediate(3), ResultPolicy.successfulWhen(_ > 0)))
// fail fast on certain errors
retry(directOperation)(RetryPolicy(Schedule.Immediate(3), ResultPolicy.retryWhen(_.getMessage != "fatal error")))
retry(eitherOperation)(RetryPolicy(Schedule.Immediate(3), ResultPolicy.retryWhen(_ != "fatal error"))(3))
```

See the tests in `ox.retry.*` for more.

## Implementation choices
### `@tailrec` vs `while`
To make the infinite policies stack-safe, the actual implementation of `retry` is tail-recursive. This resulted in some code duplication in the implementation, but it still seems more readable and nicer than the alternative variant with a plain-old `while` loop with a couple of `var`s for state management.

## Possible next steps
- multi-policies, i.e. different policies for different outcomes (e.g. retry immediately on some errors but backoff on others)
- composable policies (i.e. fall back to another policy when the original one fails)
- side-effecting callback to run on each attempt (for logging, metrics etc.)
- `repeat(operation)(Schedule)` plus a stop condition