### PR TITLE
Change fork->forkUser, forkDaemon->fork

### DIFF
--- a/core/src/main/scala/ox/channels/Channel.scala
+++ b/core/src/main/scala/ox/channels/Channel.scala
@@ -1,12 +1,6 @@
 package ox.channels
 
-import com.softwaremill.jox.{
-  Channel as JChannel,
-  Select as JSelect,
-  SelectClause as JSelectClause,
-  Sink as JSink,
-  Source as JSource
-}
+import com.softwaremill.jox.{Channel as JChannel, Select as JSelect, SelectClause as JSelectClause, Sink as JSink, Source as JSource}
 
 import scala.annotation.unchecked.uncheckedVariance
 
@@ -83,15 +77,20 @@ trait Source[+T] extends SourceOps[T]:
   def receive(): T | ChannelClosed = ChannelClosed.fromJoxOrT(delegate.receiveSafe())
 
   /** @return
-   *   `true` if no more values can be received from this channel; [[Source.receive()]] will return [[ChannelClosed]]. When closed for
-   *   receive, sending values is also not possible, [[isClosedForSend]] will return `true`.
-   */
+    *   `true` if no more values can be received from this channel; [[Source.receive()]] will return [[ChannelClosed]]. When closed for
+    *   receive, sending values is also not possible, [[isClosedForSend]] will return `true`.
+    *
+    * @return
+    *   `false`, if more values '''might''' be received from the channel, when calling [[Source.receive()]]. However, it's not guaranteed
+    *   that some values will be available. They might be received concurrently, or filtered out if the channel is created using
+    *   [[Source.mapAsView()]], [[Source.filterAsView()]] or [[Source.collectAsView()]].
+    */
   def isClosedForReceive: Boolean = delegate.isClosedForReceive
 
   /** @return
-   *   `Some` if no more values can be received from this channel; [[Source.receive()]] will return [[ChannelClosed]]. When closed for
-   *   receive, sending values is also not possible, [[isClosedForSend]] will return `true`.
-   */
+    *   `Some` if no more values can be received from this channel; [[Source.receive()]] will return [[ChannelClosed]]. When closed for
+    *   receive, sending values is also not possible, [[isClosedForSend]] will return `true`.
+    */
   def isClosedForReceiveDetail: Option[ChannelClosed] = Option(ChannelClosed.fromJoxOrT(delegate.closedForReceive()))
 
 /** Various operations which allow creating [[Source]] instances.
@@ -159,17 +158,17 @@ trait Sink[-T]:
   def done(): Unit | ChannelClosed = ChannelClosed.fromJoxOrUnit(delegate.doneSafe())
 
   /** @return
-   * `true` if no more values can be sent to this channel; [[Sink.send()]] will return [[ChannelClosed]]. When closed for send, receiving
-   * using [[Source.receive()]] might still be possible, if the channel is done, and not in an error. This can be verified using
-   * [[isClosedForReceive]].
-   */
+    *   `true` if no more values can be sent to this channel; [[Sink.send()]] will return [[ChannelClosed]]. When closed for send, receiving
+    *   using [[Source.receive()]] might still be possible, if the channel is done, and not in an error. This can be verified using
+    *   [[isClosedForReceive]].
+    */
   def isClosedForSend: Boolean = delegate.isClosedForSend
 
   /** @return
-   * `Some` if no more values can be sent to this channel; [[Sink.send()]] will return [[ChannelClosed]]. When closed for send, receiving
-   * using [[Source.receive()]] might still be possible, if the channel is done, and not in an error. This can be verified using
-   * [[isClosedForReceive]].
-   */
+    *   `Some` if no more values can be sent to this channel; [[Sink.send()]] will return [[ChannelClosed]]. When closed for send, receiving
+    *   using [[Source.receive()]] might still be possible, if the channel is done, and not in an error. This can be verified using
+    *   [[isClosedForReceive]].
+    */
   def isClosedForSendDetail: Option[ChannelClosed] = Option(ChannelClosed.fromJoxOrT(delegate.closedForSend()))
 
 //

--- a/core/src/main/scala/ox/collections.scala
+++ b/core/src/main/scala/ox/collections.scala
@@ -11,7 +11,7 @@ private[ox] def commonPar[I, O, C[E] <: Iterable[E], FO](parallelism: Int, itera
   supervised {
     val forks = iterable.map { elem =>
       s.acquire()
-      fork {
+      forkUser {
         val o = transform(elem)
         s.release()
         o

--- a/core/src/main/scala/ox/fork.scala
+++ b/core/src/main/scala/ox/fork.scala
@@ -8,41 +8,22 @@ import scala.util.control.NonFatal
 /** Starts a fork (logical thread of execution), which is guaranteed to complete before the enclosing [[supervised]] or [[scoped]] block
   * completes.
   *
-  * In case an exception is thrown while evaluating `t`, it will be thrown when calling the returned [[Fork]]'s `.join()` method.
+  * If ran in a [[supervised]] scope:
   *
-  * If ran in a supervised scope, an exception will cause the enclosing scope to end. Moreover, the scope will end only once all supervised
-  * forks (such as this one) complete.
+  *   - the fork behaves as a daemon thread
+  *   - an exception thrown while evaluating `t` will cause the enclosing scope to end (cancelling all other running forks)
+  *   - if the main body of the scope completes successfully, and all other user forks complete successfully, the scope will end, cancelling
+  *     all running forks (including this one, if it's still running). That is, successful completion of this fork isn't required to end the
+  *     scope.
+  *
+  * For alternate behaviors, see [[forkUser]], [[forkCancellable]] and [[forkUnsupervised]].
+  *
+  * If ran in an unsupervised scope ([[scoped]]):
+  *
+  *   - in case an exception is thrown while evaluating `t`, it will be thrown when calling the returned [[Fork]]'s `.join()` method.
+  *   - if the main body of the scope completes successfully, while this fork is still running, the fork will be cancelled
   */
 def fork[T](f: => T)(using Ox): Fork[T] =
-  // the separate result future is needed to wait for the result, as there's no .join on individual tasks (only whole scopes can be joined)
-  val result = new CompletableFuture[T]()
-  val ox = summon[Ox]
-  ox.supervisor.forkStarts()
-  ox.scope.fork { () =>
-    val supervisor = summon[Ox].supervisor
-    try
-      result.complete(f)
-      supervisor.forkSuccess()
-    catch
-      case e: Throwable =>
-        // we notify the supervisor first, so that if this is the first failing fork in the scope, the supervisor will 
-        // get first notified of the exception by the "original" (this) fork
-        supervisor.forkError(e)  
-        result.completeExceptionally(e)
-  }
-  newForkUsingResult(result)
-
-/** Starts a fork (logical thread of execution), which is guaranteed to complete before the enclosing [[supervised]] or [[scoped]] block
-  * exits.
-  *
-  * In case an exception is thrown while evaluating `t`, it will be thrown when calling the returned [[Fork]]'s `.join()` method.
-  *
-  * If ran in a supervised scope, an exception will cause the enclosing scope to end. However, unlike [[fork]], the enclosing scope might
-  * end (cancelling this fork) before this fork completes.
-  *
-  * If ran in an unsupervised scope, behaves the same as [[fork]].
-  */
-def forkDaemon[T](f: => T)(using Ox): Fork[T] =
   val result = new CompletableFuture[T]()
   summon[Ox].scope.fork { () =>
     val supervisor = summon[Ox].supervisor
@@ -55,11 +36,49 @@ def forkDaemon[T](f: => T)(using Ox): Fork[T] =
   newForkUsingResult(result)
 
 /** Starts a fork (logical thread of execution), which is guaranteed to complete before the enclosing [[supervised]] or [[scoped]] block
-  * exits.
+  * completes.
+  *
+  * If ran in a [[supervised]] scope:
+  *
+  *   - the fork behaves as a user-level thread
+  *   - an exception thrown while evaluating `t` will cause the enclosing scope to end (cancelling all other running forks)
+  *   - the scope won't end until the main body of the scope, and all other user forks (including this one) complete successfully. That is,
+  *     successful completion of this fork is required to end the scope.
+  *
+  * For alternate behaviors, see [[fork]], [[forkCancellable]] and [[forkUnsupervised]].
+  *
+  * If ran in an unsupervised scope ([[scoped]]):
+  *
+  *   - in case an exception is thrown while evaluating `t`, it will be thrown when calling the returned [[Fork]]'s `.join()` method.
+  *   - if the main body of the scope completes successfully, while this fork is still running, the fork will be cancelled
+  */
+def forkUser[T](f: => T)(using Ox): Fork[T] =
+  // the separate result future is needed to wait for the result, as there's no .join on individual tasks (only whole scopes can be joined)
+  val result = new CompletableFuture[T]()
+  val ox = summon[Ox]
+  ox.supervisor.forkStarts()
+  ox.scope.fork { () =>
+    val supervisor = summon[Ox].supervisor
+    try
+      result.complete(f)
+      supervisor.forkSuccess()
+    catch
+      case e: Throwable =>
+        // we notify the supervisor first, so that if this is the first failing fork in the scope, the supervisor will
+        // get first notified of the exception by the "original" (this) fork
+        supervisor.forkError(e)
+        result.completeExceptionally(e)
+  }
+  newForkUsingResult(result)
+
+/** Starts a fork (logical thread of execution), which is guaranteed to complete before the enclosing [[supervised]] or [[scoped]] block
+  * completes.
   *
   * In case an exception is thrown while evaluating `t`, it will be thrown when calling the returned [[Fork]]'s `.join()` method.
   *
-  * Success or failure isn't signalled to the supervisor. If ran in an unsupervised scope, behaves the same as [[fork]].
+  * Success or failure isn't signalled to the supervisor, and doesn't influence the scope's lifecycle.
+  *
+  * For alternate behaviors, see [[fork]], [[forkUser]] and [[forkCancellable]].
   */
 def forkUnsupervised[T](f: => T)(using Ox): Fork[T] =
   val result = new CompletableFuture[T]()
@@ -69,15 +88,28 @@ def forkUnsupervised[T](f: => T)(using Ox): Fork[T] =
   }
   newForkUsingResult(result)
 
+/** For each thunk in the given sequence, starts a fork using [[fork]]. All forks are guaranteed to complete before the enclosing
+  * [[supervised]] or [[scoped]] block completes.
+  *
+  * If ran in a [[supervised]] scope, all forks behave as daemon threads (see [[fork]] for details).
+  */
 def forkAll[T](fs: Seq[() => T])(using Ox): Fork[Seq[T]] =
   val forks = fs.map(f => fork(f()))
   new Fork[Seq[T]]:
     override def join(): Seq[T] = forks.map(_.join())
 
-/** A cancellable fork is created by starting a nested scope in a fork, and then starting a fork there. Hence, it is more expensive than
-  * `fork`, as two virtual threads are started.
+/** Starts a fork (logical thread of execution), which is guaranteed to complete before the enclosing [[supervised]] or [[scoped]] block
+  * completes, and which can be cancelled on-dmeand.
   *
-  * Otherwise, works same as [[forkUnsupervised]].
+  * In case an exception is thrown while evaluating `t`, it will be thrown when calling the returned [[Fork]]'s `.join()` method.
+  *
+  * The fork is unsupervised (similarly to [[forkUnsupervised]]), hence success or failure isn't signalled to the supervisor, and doesn't
+  * influence the scope's lifecycle.
+  *
+  * For alternate behaviors, see [[fork]], [[forkUser]] and [[forkUnsupervised]].
+  *
+  * Implementation note: a cancellable fork is created by starting a nested scope in a fork, and then starting a fork there. Hence, it is
+  * more expensive than [[fork]], as two virtual threads are started.
   */
 def forkCancellable[T](f: => T)(using Ox): CancellableFork[T] =
   val result = new CompletableFuture[T]()
@@ -133,7 +165,7 @@ private[ox] def unwrapExecutionException[T](f: => T): T =
 
 //
 
-/** A fork started using [[fork]], [[forkDaemon]] or [[forkUnsupervised]], backed by a (virtual) thread. */
+/** A fork started using [[fork]], [[forkUser]], [[forkCancellable]] or [[forkUnsupervised]], backed by a (virtual) thread. */
 trait Fork[T]:
   /** Blocks until the fork completes with a result. Throws an exception, if the fork completed with an exception. */
   def join(): T

--- a/core/src/main/scala/ox/par.scala
+++ b/core/src/main/scala/ox/par.scala
@@ -15,7 +15,7 @@ def par[T1, T2, T3](t1: => T1)(t2: => T2)(t3: => T3): (T1, T2, T3) =
 /** Runs the given computations in parallel. If any fails, interrupts the others, and re-throws the exception. */
 def par[T](ts: Seq[() => T]): Seq[T] =
   supervised {
-    val fs = ts.map(t => fork(t()))
+    val fs = ts.map(t => forkUser(t()))
     fs.map(_.join())
   }
 
@@ -26,7 +26,7 @@ def parLimit[T](parallelism: Int)(ts: Seq[() => T]): Seq[T] =
   supervised {
     val s = new Semaphore(parallelism)
     val fs = ts.map(t =>
-      fork {
+      forkUser {
         s.acquire()
         val r = t()
         // no try-finally as there's no point in releasing in case of an exception, as any newly started forks will be interrupted

--- a/core/src/main/scala/ox/race.scala
+++ b/core/src/main/scala/ox/race.scala
@@ -21,7 +21,7 @@ def timeout[T](duration: FiniteDuration)(t: => T): T =
 def raceSuccess[T](fs: Seq[() => T]): T =
   scoped {
     val result = new ArrayBlockingQueue[Try[T]](fs.size)
-    fs.foreach(f => fork(result.put(Try(f()))))
+    fs.foreach(f => forkUser(result.put(Try(f()))))
 
     @tailrec
     def takeUntilSuccess(firstException: Option[Throwable], left: Int): T =

--- a/core/src/main/scala/ox/scoped.scala
+++ b/core/src/main/scala/ox/scoped.scala
@@ -5,15 +5,19 @@ import java.util.concurrent.atomic.AtomicReference
 
 private class DoNothingScope[T] extends StructuredTaskScope[T](null, Thread.ofVirtual().factory()) {}
 
-/** Starts a new scope, which allows starting forks in the given code block `f`. Forks can be started using [[fork]].
+/** Starts a new scope, which allows starting forks in the given code block `f`. Forks can be started using [[fork]], [[forkUser]],
+  * [[forkCancellable]] and [[forkUnsupervised]]. All forks are guaranteed to complete before this scope completes.
   *
-  * The code is ran in unsupervised mode, that is:
-  *   - the scope ends once the `f` code block completes; this causes any running forks started within `f` to be cancelled
+  * '''Warning:''' It is advisable to use [[supevised]] scopes if possible, as they minimise the chances of an error to go unnoticed.
+  * [[scoped]] scopes are considered an advanced feature, and should be used with caution.
+  *
+  * The scope is ran in unsupervised mode, that is:
+  *   - the scope ends once the `f` main body completes; this causes any running forks started within `f` to be cancelled
   *   - the scope completes (that is, this method returns) only once all forks started by `f` have completed (either successfully, or with
   *     an exception)
   *   - fork failures aren't handled in any special way, but can be inspected using [[Fork.join()]]
   *
-  * Forks created using [[forkDaemon]] and [[forkUnsupervised]] will behave exactly the same as forks created using [[fork]].
+  * Forks created using [[fork]], [[forkUser]] and [[forkUnsupervised]] will behave exactly the same.
   *
   * @see
   *   [[supervised]] Starts a scope in supervised mode

--- a/core/src/main/scala/ox/syntax.scala
+++ b/core/src/main/scala/ox/syntax.scala
@@ -13,8 +13,8 @@ object syntax:
   extension [E, T](f: => Either[E, T]) def retry(policy: RetryPolicy[E, T]): Either[E, T] = ox.retry.retry(f)(policy)
 
   extension [T](f: => T)(using Ox)
+    def forkUser: Fork[T] = ox.forkUser(f)
     def fork: Fork[T] = ox.fork(f)
-    def forkDaemon: Fork[T] = ox.forkDaemon(f)
     def forkUnsupervised: Fork[T] = ox.forkUnsupervised(f)
     def forkCancellable: CancellableFork[T] = ox.forkCancellable(f)
 

--- a/core/src/test/scala/ox/ExceptionTest.scala
+++ b/core/src/test/scala/ox/ExceptionTest.scala
@@ -29,7 +29,7 @@ class ExceptionTest extends AnyFlatSpec with Matchers {
 
   it should "throw the exception thrown by a failing fork" in {
     val trail = Trail()
-    try supervised(fork(throw CustomException()))
+    try supervised(forkUser(throw CustomException()))
     catch case e: Exception => trail.add(e.getClass.getSimpleName)
 
     trail.get shouldBe Vector("CustomException")
@@ -40,13 +40,13 @@ class ExceptionTest extends AnyFlatSpec with Matchers {
     val s = Semaphore(0)
     try
       supervised {
-        fork {
+        forkUser {
           s.acquire() // will never complete
         }
-        fork {
+        forkUser {
           s.acquire() // will never complete
         }
-        fork {
+        forkUser {
           Thread.sleep(100)
           throw CustomException()
         }
@@ -64,11 +64,11 @@ class ExceptionTest extends AnyFlatSpec with Matchers {
     val s = Semaphore(0)
     try
       supervised {
-        fork {
+        forkUser {
           try s.acquire() // will never complete
           finally throw CustomException2()
         }
-        fork {
+        forkUser {
           Thread.sleep(100)
           throw CustomException()
         }

--- a/core/src/test/scala/ox/SupervisedTest.scala
+++ b/core/src/test/scala/ox/SupervisedTest.scala
@@ -13,12 +13,12 @@ class SupervisedTest extends AnyFlatSpec with Matchers {
     val trail = Trail()
 
     val result = supervised {
-      fork {
+      forkUser {
         Thread.sleep(200)
         trail.add("a")
       }
 
-      fork {
+      forkUser {
         Thread.sleep(100)
         trail.add("b")
       }
@@ -31,16 +31,16 @@ class SupervisedTest extends AnyFlatSpec with Matchers {
     trail.get shouldBe Vector("b", "a", "done")
   }
 
-  it should "not wait until daemon forks complete" in {
+  it should "only wait until user forks complete" in {
     val trail = Trail()
 
     val result = supervised {
-      forkDaemon {
+      fork {
         Thread.sleep(200)
         trail.add("a")
       }
 
-      fork {
+      forkUser {
         Thread.sleep(100)
         trail.add("b")
       }
@@ -57,17 +57,17 @@ class SupervisedTest extends AnyFlatSpec with Matchers {
     val trail = Trail()
 
     val result = Try(supervised {
-      fork {
+      forkUser {
         Thread.sleep(300)
         trail.add("a")
       }
 
-      fork {
+      forkUser {
         Thread.sleep(200)
         throw new RuntimeException("x")
       }
 
-      fork {
+      forkUser {
         Thread.sleep(100)
         trail.add("b")
       }
@@ -80,11 +80,11 @@ class SupervisedTest extends AnyFlatSpec with Matchers {
     trail.get shouldBe Vector("b", "done")
   }
 
-  it should "interrupt main fork once a fork ends with an exception" in {
+  it should "interrupt main body once a fork ends with an exception" in {
     val trail = Trail()
 
     val result = Try(supervised {
-      fork {
+      forkUser {
         Thread.sleep(200)
         throw new RuntimeException("x")
       }
@@ -102,7 +102,7 @@ class SupervisedTest extends AnyFlatSpec with Matchers {
     val trail = Trail()
 
     val result = supervised {
-      fork {
+      forkUser {
         Thread.sleep(300)
         trail.add("a")
       }
@@ -112,7 +112,7 @@ class SupervisedTest extends AnyFlatSpec with Matchers {
         throw new RuntimeException("x")
       }
 
-      fork {
+      forkUser {
         Thread.sleep(100)
         trail.add("b")
       }

--- a/core/src/test/scala/ox/channels/ChannelTest.scala
+++ b/core/src/test/scala/ox/channels/ChannelTest.scala
@@ -132,7 +132,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
       val c4 = Channel[Int](capacity)
 
       supervised {
-        forkDaemon {
+        fork {
           c2.send(10)
         }
         Thread.sleep(100) // wait for the send to suspend

--- a/core/src/test/scala/ox/channels/SourceOpsAsViewTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsAsViewTest.scala
@@ -15,7 +15,7 @@ class SourceOpsAsViewTest extends AnyFlatSpec with Matchers with Eventually {
   it should "map over a source as a view" in {
     val c: Channel[Int] = Channel()
 
-    scoped {
+    supervised {
       fork {
         c.send(10)
         c.send(20)
@@ -47,7 +47,7 @@ class SourceOpsAsViewTest extends AnyFlatSpec with Matchers with Eventually {
     val c1: Channel[Int] = Channel()
     val c2: Channel[Int] = Channel()
 
-    scoped {
+    supervised {
       fork {
         c1.send(10)
         c1.send(20)
@@ -72,7 +72,7 @@ class SourceOpsAsViewTest extends AnyFlatSpec with Matchers with Eventually {
   it should "filter over a source as a view" in {
     val c: Channel[Int] = Channel()
 
-    scoped {
+    supervised {
       fork {
         c.send(1)
         c.send(2)
@@ -93,14 +93,14 @@ class SourceOpsAsViewTest extends AnyFlatSpec with Matchers with Eventually {
     val c2: Channel[Int] = Channel()
 
     supervised {
-      forkDaemon {
+      fork {
         c1.send(1)
         c1.send(2)
         c1.send(3)
         c1.send(4)
       }
 
-      forkDaemon {
+      fork {
         c2.send(11)
         c2.send(12)
         c2.send(13)
@@ -118,7 +118,7 @@ class SourceOpsAsViewTest extends AnyFlatSpec with Matchers with Eventually {
     val c: Channel[Int] = Channel()
 
     supervised {
-      forkDaemon {
+      fork {
         c.send(1)
         c.send(2)
         c.send(3)

--- a/core/src/test/scala/ox/channels/SourceOpsEmptyTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsEmptyTest.scala
@@ -8,11 +8,11 @@ class SourceOpsEmptyTest extends AnyFlatSpec with Matchers {
 
   behavior of "Source.empty"
 
-  it should "be done" in scoped {
+  it should "be done" in supervised {
     Source.empty.isClosedForReceive shouldBe true
   }
 
-  it should "be empty" in scoped {
+  it should "be empty" in supervised {
     Source.empty.toList shouldBe empty
   }
 }

--- a/core/src/test/scala/ox/channels/SourceOpsFactoryMethodsTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsFactoryMethodsTest.scala
@@ -9,7 +9,7 @@ class SourceOpsFactoryMethodsTest extends AnyFlatSpec with Matchers {
   behavior of "Source factory methods"
 
   it should "create a source from a fork" in {
-    scoped {
+    supervised {
       val f = fork(1)
       val c = Source.fromFork(f)
       c.toList shouldBe List(1)
@@ -17,21 +17,21 @@ class SourceOpsFactoryMethodsTest extends AnyFlatSpec with Matchers {
   }
 
   it should "create an iterating source" in {
-    scoped {
+    supervised {
       val c = Source.iterate(1)(_ + 1)
       c.take(3).toList shouldBe List(1, 2, 3)
     }
   }
 
   it should "unfold a function" in {
-    scoped {
+    supervised {
       val c = Source.unfold(0)(i => if i < 3 then Some((i, i + 1)) else None)
       c.toList shouldBe List(0, 1, 2)
     }
   }
 
   it should "produce a range" in {
-    scoped {
+    supervised {
       Source.range(1, 5, 1).toList shouldBe List(1, 2, 3, 4, 5)
       Source.range(1, 5, 2).toList shouldBe List(1, 3, 5)
       Source.range(1, 11, 3).toList shouldBe List(1, 4, 7, 10)

--- a/core/src/test/scala/ox/channels/SourceOpsFailedTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsFailedTest.scala
@@ -8,7 +8,7 @@ class SourceOpsFailedTest extends AnyFlatSpec with Matchers {
 
   behavior of "Source.failed"
 
-  it should "fail on receive" in scoped {
+  it should "fail on receive" in supervised {
     // when
     val s = Source.failed(RuntimeException("boom"))
 
@@ -16,7 +16,7 @@ class SourceOpsFailedTest extends AnyFlatSpec with Matchers {
     s.receive() should matchPattern { case ChannelClosed.Error(reason) if reason.getMessage == "boom" => }
   }
 
-  it should "be in error" in scoped {
+  it should "be in error" in supervised {
     Source.failed(RuntimeException("boom")).isClosedForReceive shouldBe true
   }
 }

--- a/core/src/test/scala/ox/channels/SourceOpsInterleaveAllTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsInterleaveAllTest.scala
@@ -8,13 +8,13 @@ class SourceOpsInterleaveAllTest extends AnyFlatSpec with Matchers {
 
   behavior of "Source.interleaveAll"
 
-  it should "interleave no sources" in scoped {
+  it should "interleave no sources" in supervised {
     val s = Source.interleaveAll(List.empty)
 
     s.toList shouldBe empty
   }
 
-  it should "interleave a single source" in scoped {
+  it should "interleave a single source" in supervised {
     val c = Source.fromValues(1, 2, 3)
 
     val s = Source.interleaveAll(List(c))
@@ -22,7 +22,7 @@ class SourceOpsInterleaveAllTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(1, 2, 3)
   }
 
-  it should "interleave multiple sources" in scoped {
+  it should "interleave multiple sources" in supervised {
     val c1 = Source.fromValues(1, 2, 3, 4, 5, 6, 7, 8)
     val c2 = Source.fromValues(10, 20, 30)
     val c3 = Source.fromValues(100, 200, 300, 400, 500)
@@ -32,7 +32,7 @@ class SourceOpsInterleaveAllTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(1, 10, 100, 2, 20, 200, 3, 30, 300, 4, 400, 5, 500, 6, 7, 8)
   }
 
-  it should "interleave multiple sources using custom segment size" in scoped {
+  it should "interleave multiple sources using custom segment size" in supervised {
     val c1 = Source.fromValues(1, 2, 3, 4, 5, 6, 7, 8)
     val c2 = Source.fromValues(10, 20, 30)
     val c3 = Source.fromValues(100, 200, 300, 400, 500)
@@ -42,7 +42,7 @@ class SourceOpsInterleaveAllTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(1, 2, 10, 20, 100, 200, 3, 4, 30, 300, 400, 5, 6, 500, 7, 8)
   }
 
-  it should "interleave multiple sources using custom segment size and complete eagerly" in scoped {
+  it should "interleave multiple sources using custom segment size and complete eagerly" in supervised {
     val c1 = Source.fromValues(1, 2, 3, 4, 5, 6, 7, 8)
     val c2 = Source.fromValues(10, 20, 30)
     val c3 = Source.fromValues(100, 200, 300, 400, 500)

--- a/core/src/test/scala/ox/channels/SourceOpsInterleaveTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsInterleaveTest.scala
@@ -8,7 +8,7 @@ class SourceOpsInterleaveTest extends AnyFlatSpec with Matchers {
 
   behavior of "Source.interleave"
 
-  it should "interleave with an empty source" in scoped {
+  it should "interleave with an empty source" in supervised {
     val c1 = Source.fromValues(1, 2, 3)
     val c2 = Source.fromValues()
 
@@ -17,7 +17,7 @@ class SourceOpsInterleaveTest extends AnyFlatSpec with Matchers {
     s1.toList shouldBe List(1, 2, 3)
   }
 
-  it should "interleave two sources with default segment size" in scoped {
+  it should "interleave two sources with default segment size" in supervised {
     val c1 = Source.fromValues(1, 3, 5)
     val c2 = Source.fromValues(2, 4, 6)
 
@@ -26,7 +26,7 @@ class SourceOpsInterleaveTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(1, 2, 3, 4, 5, 6)
   }
 
-  it should "interleave two sources with default segment size and different lengths" in scoped {
+  it should "interleave two sources with default segment size and different lengths" in supervised {
     val c1 = Source.fromValues(1, 3, 5)
     val c2 = Source.fromValues(2, 4, 6, 8, 10, 12)
 
@@ -35,7 +35,7 @@ class SourceOpsInterleaveTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(1, 2, 3, 4, 5, 6, 8, 10, 12)
   }
 
-  it should "interleave two sources with custom segment size" in scoped {
+  it should "interleave two sources with custom segment size" in supervised {
     val c1 = Source.fromValues(1, 2, 3, 4)
     val c2 = Source.fromValues(10, 20, 30, 40)
 
@@ -44,7 +44,7 @@ class SourceOpsInterleaveTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(1, 2, 10, 20, 3, 4, 30, 40)
   }
 
-  it should "interleave two sources with custom segment size and different lengths" in scoped {
+  it should "interleave two sources with custom segment size and different lengths" in supervised {
     val c1 = Source.fromValues(1, 2, 3, 4, 5, 6, 7)
     val c2 = Source.fromValues(10, 20, 30, 40)
 
@@ -53,7 +53,7 @@ class SourceOpsInterleaveTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(1, 2, 10, 20, 3, 4, 30, 40, 5, 6, 7)
   }
 
-  it should "interleave two sources with different lengths and complete eagerly" in scoped {
+  it should "interleave two sources with different lengths and complete eagerly" in supervised {
     val c1 = Source.fromValues(1, 3, 5)
     val c2 = Source.fromValues(2, 4, 6, 8, 10, 12)
 
@@ -62,7 +62,7 @@ class SourceOpsInterleaveTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(1, 2, 3, 4, 5, 6)
   }
 
-  it should "when empty, interleave with a non-empty source and complete eagerly" in scoped {
+  it should "when empty, interleave with a non-empty source and complete eagerly" in supervised {
     val c1 = Source.fromValues()
     val c2 = Source.fromValues(1, 2, 3)
 
@@ -71,7 +71,7 @@ class SourceOpsInterleaveTest extends AnyFlatSpec with Matchers {
     s1.toList shouldBe empty
   }
 
-  it should "interleave with an empty source and complete eagerly" in scoped {
+  it should "interleave with an empty source and complete eagerly" in supervised {
     val c1 = Source.fromValues(1, 2, 3)
     val c2 = Source.fromValues()
 

--- a/core/src/test/scala/ox/channels/SourceOpsMapParTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsMapParTest.scala
@@ -12,7 +12,7 @@ class SourceOpsMapParTest extends AnyFlatSpec with Matchers with Eventually {
   behavior of "mapPar"
 
   for (parallelism <- 1 to 10) {
-    it should s"map over a source with parallelism limit $parallelism" in scoped {
+    it should s"map over a source with parallelism limit $parallelism" in supervised {
       // given
       val s = Source.fromIterable(1 to 10)
       val running = new AtomicInteger(0)
@@ -44,7 +44,7 @@ class SourceOpsMapParTest extends AnyFlatSpec with Matchers with Eventually {
     }
   }
 
-  it should s"map over a source with parallelism limit 10 (stress test)" in scoped {
+  it should s"map over a source with parallelism limit 10 (stress test)" in supervised {
     for (i <- 1 to 100) {
       info(s"iteration $i")
 
@@ -63,7 +63,7 @@ class SourceOpsMapParTest extends AnyFlatSpec with Matchers with Eventually {
     }
   }
 
-  it should "propagate errors" in scoped {
+  it should "propagate errors" in supervised {
     // given
     val s = Source.fromIterable(1 to 10)
     val started = new AtomicInteger()
@@ -85,7 +85,7 @@ class SourceOpsMapParTest extends AnyFlatSpec with Matchers with Eventually {
         started.get() should be <= 7 // 4 successful + at most 3 taking up all the permits
   }
 
-  it should "cancel other running forks when there's an error" in scoped {
+  it should "cancel other running forks when there's an error" in supervised {
     // given
     val trail = Trail()
     val s = Source.fromIterable(1 to 10)

--- a/core/src/test/scala/ox/channels/SourceOpsMapStatefulConcatTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsMapStatefulConcatTest.scala
@@ -8,7 +8,7 @@ class SourceOpsMapStatefulConcatTest extends AnyFlatSpec with Matchers {
 
   behavior of "Source.mapStatefulConcat"
 
-  it should "deduplicate" in scoped {
+  it should "deduplicate" in supervised {
     // given
     val c = Source.fromValues(1, 2, 2, 3, 2, 4, 3, 1, 5)
 
@@ -19,7 +19,7 @@ class SourceOpsMapStatefulConcatTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(1, 2, 3, 4, 5)
   }
 
-  it should "count consecutive" in scoped {
+  it should "count consecutive" in supervised {
     // given
     val c = Source.fromValues("apple", "apple", "apple", "banana", "orange", "orange", "apple")
 
@@ -43,7 +43,7 @@ class SourceOpsMapStatefulConcatTest extends AnyFlatSpec with Matchers {
     )
   }
 
-  it should "propagate errors in the mapping function" in scoped {
+  it should "propagate errors in the mapping function" in supervised {
     // given
     val c = Source.fromValues("a", "b", "c")
 
@@ -61,7 +61,7 @@ class SourceOpsMapStatefulConcatTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "propagate errors in the completion callback" in scoped {
+  it should "propagate errors in the completion callback" in supervised {
     // given
     val c = Source.fromValues("a", "b", "c")
 

--- a/core/src/test/scala/ox/channels/SourceOpsMapStatefulTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsMapStatefulTest.scala
@@ -8,7 +8,7 @@ class SourceOpsMapStatefulTest extends AnyFlatSpec with Matchers {
 
   behavior of "Source.mapStateful"
 
-  it should "zip with index" in scoped {
+  it should "zip with index" in supervised {
     val c = Source.fromValues("a", "b", "c")
 
     val s = c.mapStateful(() => 0)((index, element) => (index + 1, (element, index)))
@@ -16,7 +16,7 @@ class SourceOpsMapStatefulTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(("a", 0), ("b", 1), ("c", 2))
   }
 
-  it should "calculate a running total" in scoped {
+  it should "calculate a running total" in supervised {
     val c = Source.fromValues(1, 2, 3, 4, 5)
 
     val s = c.mapStateful(() => 0)((sum, element) => (sum + element, sum), Some.apply)
@@ -24,7 +24,7 @@ class SourceOpsMapStatefulTest extends AnyFlatSpec with Matchers {
     s.toList shouldBe List(0, 1, 3, 6, 10, 15)
   }
 
-  it should "propagate errors in the mapping function" in scoped {
+  it should "propagate errors in the mapping function" in supervised {
     // given
     val c = Source.fromValues("a", "b", "c")
 
@@ -42,7 +42,7 @@ class SourceOpsMapStatefulTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "propagate errors in the completion callback" in scoped {
+  it should "propagate errors in the completion callback" in supervised {
     // given
     val c = Source.fromValues("a", "b", "c")
 

--- a/core/src/test/scala/ox/channels/SourceOpsMapTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsMapTest.scala
@@ -9,7 +9,7 @@ class SourceOpsMapTest extends AnyFlatSpec with Matchers {
   behavior of "Source.map"
 
   it should "map over a source" in {
-    scoped {
+    supervised {
       val c = Channel[Int]()
       fork {
         c.send(1)
@@ -31,7 +31,7 @@ class SourceOpsMapTest extends AnyFlatSpec with Matchers {
     // this demonstrated a race condition where a cell was added by select to the waiting list by T1, completed by T2,
     // which then subsequently completed the stream; only then T1 wakes up, and checks if no new elements have been added
     for (_ <- 1 to 100000) {
-      scoped {
+      supervised {
         val c = Channel[Int]()
         fork {
           c.send(1)
@@ -47,7 +47,7 @@ class SourceOpsMapTest extends AnyFlatSpec with Matchers {
   }
 
   it should "map over a source using for-syntax" in {
-    scoped {
+    supervised {
       val c = Channel[Int]()
       fork {
         c.send(1)

--- a/core/src/test/scala/ox/channels/SourceOpsTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsTest.scala
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters.*
 class SourceOpsTest extends AnyFlatSpec with Matchers with Eventually {
 
   it should "tick regularly" in {
-    scoped {
+    supervised {
       val c = Source.tick(100.millis)
       val start = System.currentTimeMillis()
       c.receive() shouldBe ()
@@ -31,7 +31,7 @@ class SourceOpsTest extends AnyFlatSpec with Matchers with Eventually {
   }
 
   it should "timeout" in {
-    scoped {
+    supervised {
       val c = Source.timeout(100.millis)
       val start = System.currentTimeMillis()
       c.receive() shouldBe ()
@@ -41,7 +41,7 @@ class SourceOpsTest extends AnyFlatSpec with Matchers with Eventually {
   }
 
   it should "zip two sources" in {
-    scoped {
+    supervised {
       val c1 = Source.fromValues(1, 2, 3, 0)
       val c2 = Source.fromValues(4, 5, 6)
 
@@ -55,7 +55,7 @@ class SourceOpsTest extends AnyFlatSpec with Matchers with Eventually {
   }
 
   it should "merge two sources" in {
-    scoped {
+    supervised {
       val c1 = Source.fromValues(1, 2, 3)
       val c2 = Source.fromValues(4, 5, 6)
 
@@ -66,7 +66,7 @@ class SourceOpsTest extends AnyFlatSpec with Matchers with Eventually {
   }
 
   it should "pipe one source to another" in {
-    scoped {
+    supervised {
       val c1 = Source.fromValues(1, 2, 3)
       val c2 = Channel[Int]()
 
@@ -77,7 +77,7 @@ class SourceOpsTest extends AnyFlatSpec with Matchers with Eventually {
   }
 
   it should "concatenate sources" in {
-    scoped {
+    supervised {
       val s1 = Source.fromValues("a", "b", "c")
       val s2 = Source.fromValues("d", "e", "f")
       val s3 = Source.fromValues("g", "h", "i")

--- a/core/src/test/scala/ox/channels/SourceOpsTransformTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsTransformTest.scala
@@ -15,7 +15,7 @@ class SourceOpsTransformTest extends AnyFlatSpec with Matchers {
     c.send(3)
     c.done()
 
-    scoped {
+    supervised {
       c.transform(_.map(_ * 2)).toList shouldBe List(2, 4, 6)
     }
   }
@@ -28,14 +28,14 @@ class SourceOpsTransformTest extends AnyFlatSpec with Matchers {
     c.send(4)
     c.done()
 
-    scoped {
+    supervised {
       c.transform(_.drop(2).flatMap(i => List(i, i + 1, i + 2)).filter(_ % 2 == 0)).toList shouldBe List(4, 4, 6)
     }
   }
 
   it should "transform an infinite source" in {
     val c = Channel[Int]()
-    scoped {
+    supervised {
       fork {
         var i = 0
         while true do
@@ -53,7 +53,7 @@ class SourceOpsTransformTest extends AnyFlatSpec with Matchers {
   it should "transform an infinite source (stress test)" in {
     for (_ <- 1 to 1000) { // this nicely demonstrated two race conditions
       val c = Channel[Int]()
-      scoped {
+      supervised {
         fork {
           var i = 0
           while true do

--- a/core/src/test/scala/ox/channels/SourceOpsZipAllTest.scala
+++ b/core/src/test/scala/ox/channels/SourceOpsZipAllTest.scala
@@ -7,42 +7,42 @@ import ox.*
 class SourceOpsZipAllTest extends AnyFlatSpec with Matchers {
   behavior of "Source.zipAll"
 
-  it should "not emit any element when both channels are empty" in scoped {
+  it should "not emit any element when both channels are empty" in supervised {
     val s = Source.empty[Int]
     val other = Source.empty[String]
 
     s.zipAll(other, -1, "foo").toList shouldBe List.empty
   }
 
-  it should "emit this element when other channel is empty" in scoped {
+  it should "emit this element when other channel is empty" in supervised {
     val s = Source.fromValues(1)
     val other = Source.empty[String]
 
     s.zipAll(other, -1, "foo").toList shouldBe List((1, "foo"))
   }
 
-  it should "emit other element when this channel is empty" in scoped {
+  it should "emit other element when this channel is empty" in supervised {
     val s = Source.empty[Int]
     val other = Source.fromValues("a")
 
     s.zipAll(other, -1, "foo").toList shouldBe List((-1, "a"))
   }
 
-  it should "emit matching elements when both channels are of the same size" in scoped {
+  it should "emit matching elements when both channels are of the same size" in supervised {
     val s = Source.fromValues(1, 2)
     val other = Source.fromValues("a", "b")
 
     s.zipAll(other, -1, "foo").toList shouldBe List((1, "a"), (2, "b"))
   }
 
-  it should "emit default for other channel if this channel is longer" in scoped {
+  it should "emit default for other channel if this channel is longer" in supervised {
     val s = Source.fromValues(1, 2, 3)
     val other = Source.fromValues("a")
 
     s.zipAll(other, -1, "foo").toList shouldBe List((1, "a"), (2, "foo"), (3, "foo"))
   }
 
-  it should "emit default for this channel if other channel is longer" in scoped {
+  it should "emit default for this channel if other channel is longer" in supervised {
     val s = Source.fromValues(1)
     val other = Source.fromValues("a", "b", "c")
 

--- a/examples/src/test/scala/ox/crawler/Crawler.scala
+++ b/examples/src/test/scala/ox/crawler/Crawler.scala
@@ -1,7 +1,7 @@
 package ox.crawler
 
 import org.slf4j.LoggerFactory
-import ox.{Fork, forkDaemon, supervised}
+import ox.{Fork, fork, supervised}
 
 import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue}
 import scala.annotation.tailrec
@@ -55,9 +55,9 @@ object Crawler:
             case e: Exception =>
               logger.error(s"Cannot get contents of $url", e)
               List.empty[Url]
-        forkDaemon(crawlerQueue.put(CrawlResult(url, r)))
+        fork(crawlerQueue.put(CrawlResult(url, r)))
 
-      forkDaemon {
+      fork {
         while true do {
           val url = workerQueue.take
           handleUrl(url)

--- a/examples/src/test/scala/ox/main.scala
+++ b/examples/src/test/scala/ox/main.scala
@@ -4,7 +4,7 @@ import org.slf4j.LoggerFactory
 
 @main def test1 =
   val log = LoggerFactory.getLogger("test1")
-  val r = scoped {
+  val r = supervised {
     val f1 = fork {
       Thread.sleep(1000L)
       log.info("f1 done")

--- a/examples/src/test/scala/ox/sockets/Router.scala
+++ b/examples/src/test/scala/ox/sockets/Router.scala
@@ -1,7 +1,7 @@
 package ox.sockets
 
 import org.slf4j.LoggerFactory
-import ox.syntax.{forever, forkDaemon, forkCancellable}
+import ox.syntax.{forever, fork, forkCancellable}
 import ox.{CancellableFork, Fork, Ox, supervised}
 
 import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue}
@@ -54,7 +54,7 @@ object Router:
       val connectedSocket = socket.accept(Timeout)
       if connectedSocket != null then parent.put(Connected(connectedSocket))
     catch case NonFatal(e) => logger.error(s"Exception when listening on a socket", e)
-  }.forever.forkDaemon
+  }.forever.fork
 
   private def clientSend(socket: ConnectedSocket, parent: BlockingQueue[RouterMessage], sendQueue: BlockingQueue[String])(using
       Ox

--- a/examples/src/test/scala/ox/supervise/Broadcast.scala
+++ b/examples/src/test/scala/ox/supervise/Broadcast.scala
@@ -1,7 +1,7 @@
 package ox.supervise
 
 import org.slf4j.LoggerFactory
-import ox.{forever, forkDaemon, forkCancellable, supervised, uninterruptible}
+import ox.{forever, fork, forkCancellable, supervised, uninterruptible}
 
 import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue}
 import scala.annotation.tailrec
@@ -22,7 +22,7 @@ object Broadcast {
       inbox.take match
         case Subscribe(consumer) => processMessages(inbox, consumers + consumer)
         case Received(msg) =>
-          consumers.map(consumer => forkDaemon(consumer(msg)))
+          consumers.map(consumer => fork(consumer(msg)))
           processMessages(inbox, consumers)
 
     def consumeForever(inbox: BlockingQueue[BroadcastMessage]): Unit = forever {

--- a/kafka/src/main/scala/ox/kafka/KafkaConsumerActor.scala
+++ b/kafka/src/main/scala/ox/kafka/KafkaConsumerActor.scala
@@ -15,7 +15,7 @@ object KafkaConsumerActor:
   def apply[K, V](consumer: KafkaConsumer[K, V], closeWhenComplete: Boolean)(using Ox): Sink[KafkaConsumerRequest[K, V]] =
     val c = Channel[KafkaConsumerRequest[K, V]]()
 
-    forkDaemon {
+    fork {
       try
         repeatWhile {
           c.receive() match

--- a/kafka/src/main/scala/ox/kafka/KafkaSource.scala
+++ b/kafka/src/main/scala/ox/kafka/KafkaSource.scala
@@ -29,7 +29,7 @@ object KafkaSource:
 
     val c = StageCapacity.newChannel[ReceivedMessage[K, V]]
 
-    forkDaemon {
+    fork {
       try
         val pollResults = Channel[ConsumerRecords[K, V]]()
         forever {

--- a/kafka/src/main/scala/ox/kafka/KafkaStage.scala
+++ b/kafka/src/main/scala/ox/kafka/KafkaStage.scala
@@ -47,7 +47,7 @@ object KafkaStage:
 
       val sendInSequence = SendInSequence(c)
 
-      forkDaemon {
+      fork {
         try
           // starting a nested scope, so that the committer is interrupted when the main process ends
           scoped {

--- a/kafka/src/test/scala/ox/kafka/KafkaTest.scala
+++ b/kafka/src/test/scala/ox/kafka/KafkaTest.scala
@@ -92,7 +92,7 @@ class KafkaTest extends AnyFlatSpec with Matchers with EmbeddedKafka with Before
 
     supervised {
       // then
-      forkDaemon {
+      fork {
         import KafkaStage.*
 
         KafkaSource
@@ -168,7 +168,7 @@ class KafkaTest extends AnyFlatSpec with Matchers with EmbeddedKafka with Before
 
     supervised {
       // then
-      forkDaemon {
+      fork {
         KafkaSource
           .subscribe(consumerSettings, sourceTopic)
           .map(in => (in.value.toLong * 2, in))


### PR DESCRIPTION
It's most common to create daemon forks inside a supervised scope; the fact that the scope doesn't end until all user forks (previously created with `fork`) might be suprising for the users (as the code seems to hang), hence the change.