### PR TITLE
Make unsupervised scopes more type safe, rename scoped to unsupervised, forkUnsupervised to forkPlain

### DIFF
--- a/core/src/main/scala/ox/Ox.scala
+++ b/core/src/main/scala/ox/Ox.scala
@@ -6,7 +6,7 @@ import scala.annotation.implicitNotFound
 
 /** Represents a capability to:
   *   - fork unsupervised, asynchronously running computations in a concurrency scope. Such forks can be created e.g. using
-  *     [[forkUnsupervised]].
+  *     [[forkPlain]].
   *   - register resources to be cleaned up after the scope ends
   *
   * This capability is provided by scopes created using [[supervised]], [[supervisedError]] or [[unsupervised]].
@@ -17,7 +17,7 @@ import scala.annotation.implicitNotFound
 @implicitNotFound(
   "This operation must be run within a `supervised`, `supervisedError` or `unsupervised` block. Alternatively, you must require that the enclosing method is run within a scope, by adding a `using Ox` parameter list."
 )
-trait OxUnsupervised:
+trait OxPlain:
   private[ox] def scope: StructuredTaskScope[Any]
   private[ox] def finalizers: AtomicReference[List[() => Unit]]
   private[ox] def supervisor: Supervisor[Nothing]
@@ -36,7 +36,7 @@ trait OxUnsupervised:
 @implicitNotFound(
   "This operation must be run within a `supervised` or `supervisedError` block. Alternatively, you must require that the enclosing method is run within a scope, by adding a `using Ox` parameter list."
 )
-trait Ox extends OxUnsupervised:
+trait Ox extends OxPlain:
   private[ox] def asNoErrorMode: OxError[Nothing, [T] =>> T]
 
 /** Represents a capability to:

--- a/core/src/main/scala/ox/Ox.scala
+++ b/core/src/main/scala/ox/Ox.scala
@@ -9,13 +9,13 @@ import scala.annotation.implicitNotFound
   *     [[forkUnsupervised]].
   *   - register resources to be cleaned up after the scope ends
   *
-  * This capability is provided by scopes created using [[supervised]], [[supervisedError]] or [[scoped]].
+  * This capability is provided by scopes created using [[supervised]], [[supervisedError]] or [[unsupervised]].
   *
   * @see
   *   [[Ox]], [[OxError]]
   */
 @implicitNotFound(
-  "This operation must be run within a `supervised`, `supervisedError` or `scoped` block. Alternatively, you must require that the enclosing method is run within a scope, by adding a `using Ox` parameter list."
+  "This operation must be run within a `supervised`, `supervisedError` or `unsupervised` block. Alternatively, you must require that the enclosing method is run within a scope, by adding a `using Ox` parameter list."
 )
 trait OxUnsupervised:
   private[ox] def scope: StructuredTaskScope[Any]

--- a/core/src/main/scala/ox/channels/SourceOps.scala
+++ b/core/src/main/scala/ox/channels/SourceOps.scala
@@ -181,7 +181,7 @@ trait SourceOps[+T] { outer: Source[T] =>
     val closeScope = new CountDownLatch(1)
     unsupervised {
       // enqueueing fork
-      forkUnsupervised {
+      forkPlain {
         repeatWhile {
           s.acquire()
           receiveSafe() match
@@ -194,7 +194,7 @@ trait SourceOps[+T] { outer: Source[T] =>
               closeScope.countDown()
               false
             case t: T @unchecked =>
-              inProgress.sendSafe(forkUnsupervised {
+              inProgress.sendSafe(forkPlain {
                 try
                   val u = f(t)
                   s.release() // not in finally, as in case of an exception, no point in starting subsequent forks
@@ -210,7 +210,7 @@ trait SourceOps[+T] { outer: Source[T] =>
       }
 
       // sending fork
-      forkUnsupervised {
+      forkPlain {
         repeatWhile {
           inProgress.receiveSafe() match
             case f: Fork[Option[U]] @unchecked =>

--- a/core/src/main/scala/ox/channels/SourceOps.scala
+++ b/core/src/main/scala/ox/channels/SourceOps.scala
@@ -181,7 +181,7 @@ trait SourceOps[+T] { outer: Source[T] =>
     val closeScope = new CountDownLatch(1)
     scoped {
       // enqueueing fork
-      fork {
+      forkUnsupervised {
         repeatWhile {
           s.acquire()
           receiveSafe() match
@@ -194,7 +194,7 @@ trait SourceOps[+T] { outer: Source[T] =>
               closeScope.countDown()
               false
             case t: T @unchecked =>
-              inProgress.sendSafe(fork {
+              inProgress.sendSafe(forkUnsupervised {
                 try
                   val u = f(t)
                   s.release() // not in finally, as in case of an exception, no point in starting subsequent forks
@@ -210,7 +210,7 @@ trait SourceOps[+T] { outer: Source[T] =>
       }
 
       // sending fork
-      fork {
+      forkUnsupervised {
         repeatWhile {
           inProgress.receiveSafe() match
             case f: Fork[Option[U]] @unchecked =>

--- a/core/src/main/scala/ox/channels/SourceOps.scala
+++ b/core/src/main/scala/ox/channels/SourceOps.scala
@@ -179,7 +179,7 @@ trait SourceOps[+T] { outer: Source[T] =>
     val s = new Semaphore(parallelism)
     val inProgress = Channel.withCapacity[Fork[Option[U]]](parallelism)
     val closeScope = new CountDownLatch(1)
-    scoped {
+    unsupervised {
       // enqueueing fork
       forkUnsupervised {
         repeatWhile {
@@ -629,7 +629,7 @@ trait SourceOps[+T] { outer: Source[T] =>
     *
     *   import scala.concurrent.duration.*
     *
-    *   scoped {
+    *   supervised {
     *     Source.empty[Int].throttle(1, 1.second).toList       // List() returned without throttling
     *     Source.fromValues(1, 2).throttle(1, 1.second).toList // List(1, 2) returned after 2 seconds
     *   }

--- a/core/src/main/scala/ox/fork.scala
+++ b/core/src/main/scala/ox/fork.scala
@@ -97,7 +97,7 @@ def forkUserError[E, F[_], T](using OxError[E, F])(f: => F[T]): Fork[T] =
   newForkUsingResult(result)
 
 /** Starts a fork (logical thread of execution), which is guaranteed to complete before the enclosing [[supervised]], [[supervisedError]] or
-  * [[scoped]] block completes.
+  * [[unsupervised]] block completes.
   *
   * In case an exception is thrown while evaluating `t`, it will be thrown when calling the returned [[Fork]]'s `.join()` method.
   *
@@ -114,7 +114,7 @@ def forkUnsupervised[T](f: => T)(using OxUnsupervised): Fork[T] =
   newForkUsingResult(result)
 
 /** For each thunk in the given sequence, starts a fork using [[fork]]. All forks are guaranteed to complete before the enclosing
-  * [[supervised]] or [[scoped]] block completes.
+  * [[supervised]] or [[unsupervised]] block completes.
   *
   * If ran in a [[supervised]] scope, all forks behave as daemon threads (see [[fork]] for details).
   */
@@ -124,7 +124,7 @@ def forkAll[T](fs: Seq[() => T])(using Ox): Fork[Seq[T]] =
     override def join(): Seq[T] = forks.map(_.join())
 
 /** Starts a fork (logical thread of execution), which is guaranteed to complete before the enclosing [[supervised]], [[supervisedError]] or
-  * [[scoped]] block completes, and which can be cancelled on-demand.
+  * [[unsupervised]] block completes, and which can be cancelled on-demand.
   *
   * In case an exception is thrown while evaluating `t`, it will be thrown when calling the returned [[Fork]]'s `.join()` method.
   *

--- a/core/src/main/scala/ox/fork.scala
+++ b/core/src/main/scala/ox/fork.scala
@@ -16,7 +16,7 @@ import scala.util.control.NonFatal
   * forks).
   *
   * For alternate behaviors regarding ending the scope, see [[forkUser]], [[forkError]], [[forkUserError]], [[forkCancellable]] and
-  * [[forkUnsupervised]].
+  * [[forkPlain]].
   */
 def fork[T](f: => T)(using Ox): Fork[T] = forkError(using summon[Ox].asNoErrorMode)(f)
 
@@ -61,7 +61,7 @@ def forkError[E, F[_], T](using OxError[E, F])(f: => F[T]): Fork[T] =
   *
   * An exception thrown while evaluating `t` will cause the enclosing scope to end (cancelling all other running forks).
   *
-  * For alternate behaviors, see [[fork]], [[forkError]], [[forkUserError]], [[forkCancellable]] and [[forkUnsupervised]].
+  * For alternate behaviors, see [[fork]], [[forkError]], [[forkUserError]], [[forkCancellable]] and [[forkPlain]].
   */
 def forkUser[T](f: => T)(using Ox): Fork[T] = forkUserError(using summon[Ox].asNoErrorMode)(f)
 
@@ -105,9 +105,9 @@ def forkUserError[E, F[_], T](using OxError[E, F])(f: => F[T]): Fork[T] =
   *
   * For alternate behaviors, see [[fork]], [[forkUser]] and [[forkCancellable]].
   */
-def forkUnsupervised[T](f: => T)(using OxUnsupervised): Fork[T] =
+def forkPlain[T](f: => T)(using OxPlain): Fork[T] =
   val result = new CompletableFuture[T]()
-  summon[OxUnsupervised].scope.fork { () =>
+  summon[OxPlain].scope.fork { () =>
     try result.complete(f)
     catch case e: Throwable => result.completeExceptionally(e)
   }
@@ -128,21 +128,21 @@ def forkAll[T](fs: Seq[() => T])(using Ox): Fork[Seq[T]] =
   *
   * In case an exception is thrown while evaluating `t`, it will be thrown when calling the returned [[Fork]]'s `.join()` method.
   *
-  * The fork is unsupervised (similarly to [[forkUnsupervised]]), hence success or failure isn't signalled to the enclosing scope and
+  * The fork is unsupervised (similarly to [[forkPlain]]), hence success or failure isn't signalled to the enclosing scope and
   * doesn't influence the scope's lifecycle.
   *
-  * For alternate behaviors, see [[fork]], [[forkError]], [[forkUser]], [[forkUserError]] and [[forkUnsupervised]].
+  * For alternate behaviors, see [[fork]], [[forkError]], [[forkUser]], [[forkUserError]] and [[forkPlain]].
   *
   * Implementation note: a cancellable fork is created by starting a nested scope in a fork, and then starting a fork there. Hence, it is
   * more expensive than [[fork]], as two virtual threads are started.
   */
-def forkCancellable[T](f: => T)(using OxUnsupervised): CancellableFork[T] =
+def forkCancellable[T](f: => T)(using OxPlain): CancellableFork[T] =
   val result = new CompletableFuture[T]()
   // forks can be never run, if they are cancelled immediately - we need to detect this, not to await on result.get()
   val started = new AtomicBoolean(false)
   // interrupt signal
   val done = new Semaphore(0)
-  val ox = summon[OxUnsupervised]
+  val ox = summon[OxPlain]
   ox.scope.fork { () =>
     scopedWithCapability(OxError(ox.supervisor, NoErrorMode)) {
       val nestedOx = summon[Ox]
@@ -188,7 +188,7 @@ private[ox] inline def unwrapExecutionException[T](f: => T): T =
 
 //
 
-/** A fork started using [[fork]], [[forkError]], [[forkUser]], [[forkUserError]], [[forkCancellable]] or [[forkUnsupervised]], backed by a
+/** A fork started using [[fork]], [[forkError]], [[forkUser]], [[forkUserError]], [[forkCancellable]] or [[forkPlain]], backed by a
   * (virtual) thread.
   */
 trait Fork[T]:

--- a/core/src/main/scala/ox/local.scala
+++ b/core/src/main/scala/ox/local.scala
@@ -16,7 +16,7 @@ class ForkLocal[T](scopedValue: ScopedValue[T], default: T):
     * **Warning:** It is advisable to use [[supervised]] scopes if possible, as they minimise the chances of an error to go unnoticed.
     * [[unsupervised]] scopes are considered an advanced feature, and should be used with caution.
     */
-  def unsupervisedWhere[U](newValue: T)(f: OxUnsupervised ?=> U): U =
+  def unsupervisedWhere[U](newValue: T)(f: OxPlain ?=> U): U =
     // the scoped values need to be set inside the thread that's used to create the new scope, but
     // before starting the scope itself, as scoped value bindings can't change after the scope is started
     scopedValueWhere(scopedValue, newValue)(unsupervised(f))

--- a/core/src/main/scala/ox/local.scala
+++ b/core/src/main/scala/ox/local.scala
@@ -16,7 +16,7 @@ class ForkLocal[T](scopedValue: ScopedValue[T], default: T):
     * **Warning:** It is advisable to use [[supervised]] scopes if possible, as they minimise the chances of an error to go unnoticed.
     * [[scoped]] scopes are considered an advanced feature, and should be used with caution.
     */
-  def scopedWhere[U](newValue: T)(f: Ox ?=> U): U =
+  def scopedWhere[U](newValue: T)(f: OxUnsupervised ?=> U): U =
     // the scoped values need to be set inside the thread that's used to create the new scope, but
     // before starting the scope itself, as scoped value bindings can't change after the scope is started
     scopedValueWhere(scopedValue, newValue)(scoped(f))

--- a/core/src/main/scala/ox/local.scala
+++ b/core/src/main/scala/ox/local.scala
@@ -8,18 +8,18 @@ private def scopedValueWhere[T, U](sv: ScopedValue[T], t: T)(f: => U): U =
 class ForkLocal[T](scopedValue: ScopedValue[T], default: T):
   def get(): T = scopedValue.orElse(default)
 
-  /** Creates a new [[scoped]] scope, where the value of this fork local is set to `newValue`, only for the duration of the scope.
+  /** Creates a new [[unsupervised]] scope, where the value of this fork local is set to `newValue`, only for the duration of the scope.
     *
     * **Warning:** due to the "structured" nature of setting a fork local's value, forks using external (wider) scopes should not be
     * created, as an attempt to do so will throw a [[java.util.concurrent.StructureViolationException]].
     *
     * **Warning:** It is advisable to use [[supervised]] scopes if possible, as they minimise the chances of an error to go unnoticed.
-    * [[scoped]] scopes are considered an advanced feature, and should be used with caution.
+    * [[unsupervised]] scopes are considered an advanced feature, and should be used with caution.
     */
-  def scopedWhere[U](newValue: T)(f: OxUnsupervised ?=> U): U =
+  def unsupervisedWhere[U](newValue: T)(f: OxUnsupervised ?=> U): U =
     // the scoped values need to be set inside the thread that's used to create the new scope, but
     // before starting the scope itself, as scoped value bindings can't change after the scope is started
-    scopedValueWhere(scopedValue, newValue)(scoped(f))
+    scopedValueWhere(scopedValue, newValue)(unsupervised(f))
 
   /** Creates a new [[supervised]] scope, where the value of this fork local is set to `newValue`, only for the duration of the scope.
     *

--- a/core/src/main/scala/ox/race.scala
+++ b/core/src/main/scala/ox/race.scala
@@ -31,7 +31,7 @@ def race[T](fs: Seq[() => T]): T = race(NoErrorMode)(fs)
   * an `F`-wrapped value.
   */
 def race[E, F[_], T](em: ErrorMode[E, F])(fs: Seq[() => F[T]]): F[T] =
-  scoped {
+  unsupervised {
     val result = new ArrayBlockingQueue[Try[F[T]]](fs.size)
     fs.foreach(f => forkUnsupervised(result.put(Try(f()))))
 

--- a/core/src/main/scala/ox/race.scala
+++ b/core/src/main/scala/ox/race.scala
@@ -33,7 +33,7 @@ def race[T](fs: Seq[() => T]): T = race(NoErrorMode)(fs)
 def race[E, F[_], T](em: ErrorMode[E, F])(fs: Seq[() => F[T]]): F[T] =
   scoped {
     val result = new ArrayBlockingQueue[Try[F[T]]](fs.size)
-    fs.foreach(f => fork(result.put(Try(f()))))
+    fs.foreach(f => forkUnsupervised(result.put(Try(f()))))
 
     @tailrec
     def takeUntilSuccess(failures: Vector[Either[E, Throwable]], left: Int): F[T] =

--- a/core/src/main/scala/ox/race.scala
+++ b/core/src/main/scala/ox/race.scala
@@ -33,7 +33,7 @@ def race[T](fs: Seq[() => T]): T = race(NoErrorMode)(fs)
 def race[E, F[_], T](em: ErrorMode[E, F])(fs: Seq[() => F[T]]): F[T] =
   unsupervised {
     val result = new ArrayBlockingQueue[Try[F[T]]](fs.size)
-    fs.foreach(f => forkUnsupervised(result.put(Try(f()))))
+    fs.foreach(f => forkPlain(result.put(Try(f()))))
 
     @tailrec
     def takeUntilSuccess(failures: Vector[Either[E, Throwable]], left: Int): F[T] =

--- a/core/src/main/scala/ox/resource.scala
+++ b/core/src/main/scala/ox/resource.scala
@@ -3,27 +3,27 @@ package ox
 /** Use the given resource in the current concurrency scope. The resource is allocated using `acquire`, and released after the all forks in
   * the scope complete (either successfully or with an error), using `release`. Releasing is uninterruptible.
   */
-def useInScope[T](acquire: => T)(release: T => Unit)(using OxUnsupervised): T =
+def useInScope[T](acquire: => T)(release: T => Unit)(using OxPlain): T =
   val t = acquire
-  summon[OxUnsupervised].addFinalizer(() => release(t))
+  summon[OxPlain].addFinalizer(() => release(t))
   t
 
 /** Use the given resource, which implements [[AutoCloseable]], in the current concurrency scope. The resource is allocated using `acquire`,
   * and released after the all forks in the scope complete (either successfully or with an error), using [[AutoCloseable.close()]].
   * Releasing is uninterruptible.
   */
-def useCloseableInScope[T <: AutoCloseable](c: => T)(using OxUnsupervised): T = useInScope(c)(_.close())
+def useCloseableInScope[T <: AutoCloseable](c: => T)(using OxPlain): T = useInScope(c)(_.close())
 
 /** Release the given resource, by running the `release` code block. Releasing is done after all the forks in the scope complete (either
   * successfully or with an error), but before the current concurrency scope completes. Releasing is uninterruptible.
   */
-def releaseAfterScope(release: => Unit)(using OxUnsupervised): Unit = useInScope(())(_ => release)
+def releaseAfterScope(release: => Unit)(using OxPlain): Unit = useInScope(())(_ => release)
 
 /** Release the given resource, which implements [[AutoCloseable]], by running its `.close()` method. Releasing is done after all the forks
   * in the scope complete (either successfully or with an error), but before the current concurrency scope completes. Releasing is
   * uninterruptible.
   */
-def releaseCloseableAfterScope(toRelease: AutoCloseable)(using OxUnsupervised): Unit = useInScope(())(_ => toRelease.close())
+def releaseCloseableAfterScope(toRelease: AutoCloseable)(using OxPlain): Unit = useInScope(())(_ => toRelease.close())
 
 /** Use the given resource, acquired using `acquire` and released using `release` in the given `f` code block. Releasing is uninterruptible.
   * To use multiple resource, consider created a [[supervised]] scope and [[useInScope]] method.

--- a/core/src/main/scala/ox/resource.scala
+++ b/core/src/main/scala/ox/resource.scala
@@ -3,27 +3,27 @@ package ox
 /** Use the given resource in the current concurrency scope. The resource is allocated using `acquire`, and released after the all forks in
   * the scope complete (either successfully or with an error), using `release`. Releasing is uninterruptible.
   */
-def useInScope[T](acquire: => T)(release: T => Unit)(using Ox): T =
+def useInScope[T](acquire: => T)(release: T => Unit)(using OxUnsupervised): T =
   val t = acquire
-  summon[Ox].addFinalizer(() => release(t))
+  summon[OxUnsupervised].addFinalizer(() => release(t))
   t
 
 /** Use the given resource, which implements [[AutoCloseable]], in the current concurrency scope. The resource is allocated using `acquire`,
   * and released after the all forks in the scope complete (either successfully or with an error), using [[AutoCloseable.close()]].
   * Releasing is uninterruptible.
   */
-def useCloseableInScope[T <: AutoCloseable](c: => T)(using Ox): T = useInScope(c)(_.close())
+def useCloseableInScope[T <: AutoCloseable](c: => T)(using OxUnsupervised): T = useInScope(c)(_.close())
 
 /** Release the given resource, by running the `release` code block. Releasing is done after all the forks in the scope complete (either
   * successfully or with an error), but before the current concurrency scope completes. Releasing is uninterruptible.
   */
-def releaseAfterScope(release: => Unit)(using Ox): Unit = useInScope(())(_ => release)
+def releaseAfterScope(release: => Unit)(using OxUnsupervised): Unit = useInScope(())(_ => release)
 
 /** Release the given resource, which implements [[AutoCloseable]], by running its `.close()` method. Releasing is done after all the forks
   * in the scope complete (either successfully or with an error), but before the current concurrency scope completes. Releasing is
   * uninterruptible.
   */
-def releaseCloseableAfterScope(toRelease: AutoCloseable)(using Ox): Unit = useInScope(())(_ => toRelease.close())
+def releaseCloseableAfterScope(toRelease: AutoCloseable)(using OxUnsupervised): Unit = useInScope(())(_ => toRelease.close())
 
 /** Use the given resource, acquired using `acquire` and released using `release` in the given `f` code block. Releasing is uninterruptible.
   * To use multiple resource, consider created a [[supervised]] scope and [[useInScope]] method.

--- a/core/src/main/scala/ox/scoped.scala
+++ b/core/src/main/scala/ox/scoped.scala
@@ -23,7 +23,7 @@ private class DoNothingScope[T] extends StructuredTaskScope[T](null, Thread.ofVi
   * @see
   *   [[supervised]] Starts a scope in supervised mode
   */
-def scoped[T](f: Ox ?=> T): T =
+def scoped[T](f: OxUnsupervised ?=> T): T =
   scopedWithCapability(OxError(NoOpSupervisor, NoErrorMode))(f)
 
 private[ox] def scopedWithCapability[T](capability: Ox)(f: Ox ?=> T): T =

--- a/core/src/main/scala/ox/supervised.scala
+++ b/core/src/main/scala/ox/supervised.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
 import scala.reflect.ClassTag
 
 /** Starts a new concurrency scope, which allows starting forks in the given code block `f`. Forks can be started using [[fork]],
-  * [[forkUser]], [[forkCancellable]] and [[forkUnsupervised]]. All forks are guaranteed to complete before this scope completes.
+  * [[forkUser]], [[forkCancellable]] and [[forkPlain]]. All forks are guaranteed to complete before this scope completes.
   *
   * The scope is ran in supervised mode, that is:
   *   - the scope ends once all user, supervised forks (started using [[forkUser]]), including the `f` body, succeed. Forks started using
@@ -21,14 +21,13 @@ import scala.reflect.ClassTag
   *
   * @see
   * [[unsupervised]] Starts a scope in unsupervised mode
-  *
   * @see
   * [[supervisedError]] Starts a scope in supervised mode, with the additional ability to report application errors
   */
 def supervised[T](f: Ox ?=> T): T = supervisedError(NoErrorMode)(f)
 
 /** Starts a new concurrency scope, which allows starting forks in the given code block `f`. Forks can be started using [[fork]],
-  * [[forkError]], [[forkUser]], [[forkUserError]], [[forkCancellable]] and [[forkUnsupervised]]. All forks are guaranteed to complete
+  * [[forkError]], [[forkUser]], [[forkUserError]], [[forkCancellable]] and [[forkPlain]]. All forks are guaranteed to complete
   * before this scope completes.
   *
   * Behaves the same as [[supervised]], but additionally allows reporting application errors represented as values of type `E` in context

--- a/core/src/main/scala/ox/supervised.scala
+++ b/core/src/main/scala/ox/supervised.scala
@@ -11,8 +11,8 @@ import scala.reflect.ClassTag
   *   - the scope ends once all user, supervised forks (started using [[forkUser]]), including the `f` body, succeed. Forks started using
   *     [[fork]] (daemon) don't have to complete successfully for the scope to end.
   *   - the scope also ends once the first supervised fork (including the `f` main body) fails with an exception
-  *   - when the scope ends, all running forks are cancelled
-  *   - the scope completes (that is, this method returns) only once all forks started by `f` have completed (either successfully, or with
+  *   - when the scope **ends**, all running forks are cancelled
+  *   - the scope **completes** (that is, this method returns) only once all forks started by `f` have completed (either successfully, or with
   *     an exception)
   *
   * Upon successful completion, returns the result of evaluating `f`. Upon failure, the exception that caused the scope to end is re-thrown

--- a/core/src/main/scala/ox/supervised.scala
+++ b/core/src/main/scala/ox/supervised.scala
@@ -20,10 +20,10 @@ import scala.reflect.ClassTag
   * are added as suppressed.
   *
   * @see
-  *   [[scoped]] Starts a scope in unsupervised mode
+  * [[unsupervised]] Starts a scope in unsupervised mode
   *
   * @see
-  *   [[supervisedError]] Starts a scope in supervised mode, with the additional ability to report application errors
+  * [[supervisedError]] Starts a scope in supervised mode, with the additional ability to report application errors
   */
 def supervised[T](f: Ox ?=> T): T = supervisedError(NoErrorMode)(f)
 

--- a/core/src/main/scala/ox/unsupervised.scala
+++ b/core/src/main/scala/ox/unsupervised.scala
@@ -4,19 +4,16 @@ import java.util.concurrent.StructuredTaskScope
 
 private class DoNothingScope[T] extends StructuredTaskScope[T](null, Thread.ofVirtual().factory()) {}
 
-/** Starts a new concurrency scope, which allows starting forks in the given code block `f`. Forks can be started using [[fork]],
-  * [[forkUser]], [[forkCancellable]] and [[forkPlain]]. All forks are guaranteed to complete before this scope completes.
+/** Starts a new concurrency scope, which allows starting forks in the given code block `f`. Forks can be started using [[forkPlain]], and
+  * [[forkCancellable]]. All forks are guaranteed to complete before this scope completes.
   *
-  * **Warning:** It is advisable to use [[supervised]] scopes if possible, as they minimise the chances of an error to go unnoticed.
-  * `unsupervised` scopes are considered an advanced feature, and should be used with caution.
+  * It is advisable to use [[supervised]] scopes if possible, as they minimise the chances of an error to go unnoticed.
   *
   * The scope is ran in unsupervised mode, that is:
   *   - the scope ends once the `f` body completes; this causes any running forks started within `f` to be cancelled
   *   - the scope completes (that is, this method returns) only once all forks started by `f` have completed (either successfully, or with
   *     an exception)
   *   - fork failures aren't handled in any special way, but can be inspected using [[Fork.join()]]
-  *
-  * Forks created using [[fork]], [[forkUser]] and [[forkPlain]] will behave exactly the same.
   *
   * Upon successful completion, returns the result of evaluating `f`. Upon failure, that is an exception thrown by `f`, it is re-thrown.
   *

--- a/core/src/main/scala/ox/unsupervised.scala
+++ b/core/src/main/scala/ox/unsupervised.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.StructuredTaskScope
 private class DoNothingScope[T] extends StructuredTaskScope[T](null, Thread.ofVirtual().factory()) {}
 
 /** Starts a new concurrency scope, which allows starting forks in the given code block `f`. Forks can be started using [[fork]],
-  * [[forkUser]], [[forkCancellable]] and [[forkUnsupervised]]. All forks are guaranteed to complete before this scope completes.
+  * [[forkUser]], [[forkCancellable]] and [[forkPlain]]. All forks are guaranteed to complete before this scope completes.
   *
   * **Warning:** It is advisable to use [[supervised]] scopes if possible, as they minimise the chances of an error to go unnoticed.
   * `unsupervised` scopes are considered an advanced feature, and should be used with caution.
@@ -16,14 +16,14 @@ private class DoNothingScope[T] extends StructuredTaskScope[T](null, Thread.ofVi
   *     an exception)
   *   - fork failures aren't handled in any special way, but can be inspected using [[Fork.join()]]
   *
-  * Forks created using [[fork]], [[forkUser]] and [[forkUnsupervised]] will behave exactly the same.
+  * Forks created using [[fork]], [[forkUser]] and [[forkPlain]] will behave exactly the same.
   *
   * Upon successful completion, returns the result of evaluating `f`. Upon failure, that is an exception thrown by `f`, it is re-thrown.
   *
   * @see
   *   [[supervised]] Starts a scope in supervised mode
   */
-def unsupervised[T](f: OxUnsupervised ?=> T): T =
+def unsupervised[T](f: OxPlain ?=> T): T =
   scopedWithCapability(OxError(NoOpSupervisor, NoErrorMode))(f)
 
 private[ox] def scopedWithCapability[T](capability: Ox)(f: Ox ?=> T): T =

--- a/core/src/main/scala/ox/unsupervised.scala
+++ b/core/src/main/scala/ox/unsupervised.scala
@@ -8,7 +8,7 @@ private class DoNothingScope[T] extends StructuredTaskScope[T](null, Thread.ofVi
   * [[forkUser]], [[forkCancellable]] and [[forkUnsupervised]]. All forks are guaranteed to complete before this scope completes.
   *
   * **Warning:** It is advisable to use [[supervised]] scopes if possible, as they minimise the chances of an error to go unnoticed.
-  * [[scoped]] scopes are considered an advanced feature, and should be used with caution.
+  * `unsupervised` scopes are considered an advanced feature, and should be used with caution.
   *
   * The scope is ran in unsupervised mode, that is:
   *   - the scope ends once the `f` body completes; this causes any running forks started within `f` to be cancelled
@@ -23,7 +23,7 @@ private class DoNothingScope[T] extends StructuredTaskScope[T](null, Thread.ofVi
   * @see
   *   [[supervised]] Starts a scope in supervised mode
   */
-def scoped[T](f: OxUnsupervised ?=> T): T =
+def unsupervised[T](f: OxUnsupervised ?=> T): T =
   scopedWithCapability(OxError(NoOpSupervisor, NoErrorMode))(f)
 
 private[ox] def scopedWithCapability[T](capability: Ox)(f: Ox ?=> T): T =

--- a/core/src/main/scala/ox/util.scala
+++ b/core/src/main/scala/ox/util.scala
@@ -90,7 +90,7 @@ extension [T](inline f: Future[T])
 /** Prevent `f` from being interrupted. Any interrupted exceptions that occur while evaluating `f` will be re-thrown once it completes. */
 inline def uninterruptible[T](inline f: T): T =
   scoped {
-    val t = fork(f)
+    val t = forkUnsupervised(f)
 
     def joinDespiteInterrupted: T =
       try t.join()

--- a/core/src/main/scala/ox/util.scala
+++ b/core/src/main/scala/ox/util.scala
@@ -90,7 +90,7 @@ extension [T](inline f: Future[T])
 /** Prevent `f` from being interrupted. Any interrupted exceptions that occur while evaluating `f` will be re-thrown once it completes. */
 inline def uninterruptible[T](inline f: T): T =
   unsupervised {
-    val t = forkUnsupervised(f)
+    val t = forkPlain(f)
 
     def joinDespiteInterrupted: T =
       try t.join()

--- a/core/src/main/scala/ox/util.scala
+++ b/core/src/main/scala/ox/util.scala
@@ -89,7 +89,7 @@ extension [T](inline f: Future[T])
 
 /** Prevent `f` from being interrupted. Any interrupted exceptions that occur while evaluating `f` will be re-thrown once it completes. */
 inline def uninterruptible[T](inline f: T): T =
-  scoped {
+  unsupervised {
     val t = forkUnsupervised(f)
 
     def joinDespiteInterrupted: T =

--- a/core/src/test/scala/ox/ControlTest.scala
+++ b/core/src/test/scala/ox/ControlTest.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.DurationInt
 class ControlTest extends AnyFlatSpec with Matchers {
   "timeout" should "short-circuit a long computation" in {
     val trail = Trail()
-    scoped {
+    unsupervised {
       try
         timeout(1.second) {
           sleep(2.seconds)
@@ -28,7 +28,7 @@ class ControlTest extends AnyFlatSpec with Matchers {
 
   it should "not interrupt a short computation" in {
     val trail = Trail()
-    scoped {
+    unsupervised {
       try
         timeout(1.second) {
           sleep(100.millis)

--- a/core/src/test/scala/ox/ExceptionTest.scala
+++ b/core/src/test/scala/ox/ExceptionTest.scala
@@ -15,7 +15,7 @@ class ExceptionTest extends AnyFlatSpec with Matchers {
 
   "scoped" should "throw the exception thrown by a joined fork" in {
     val trail = Trail()
-    try scoped(fork(throw CustomException()).join())
+    try scoped(forkUnsupervised(throw CustomException()).join())
     catch case e: Exception => trail.add(e.getClass.getSimpleName)
 
     trail.get shouldBe Vector("CustomException")

--- a/core/src/test/scala/ox/ExceptionTest.scala
+++ b/core/src/test/scala/ox/ExceptionTest.scala
@@ -13,9 +13,9 @@ class ExceptionTest extends AnyFlatSpec with Matchers {
   class CustomException2 extends RuntimeException
   class CustomException3(e: Exception) extends RuntimeException(e)
 
-  "scoped" should "throw the exception thrown by a joined fork" in {
+  "unsupervised" should "throw the exception thrown by a joined fork" in {
     val trail = Trail()
-    try scoped(forkUnsupervised(throw CustomException()).join())
+    try unsupervised(forkUnsupervised(throw CustomException()).join())
     catch case e: Exception => trail.add(e.getClass.getSimpleName)
 
     trail.get shouldBe Vector("CustomException")

--- a/core/src/test/scala/ox/ExceptionTest.scala
+++ b/core/src/test/scala/ox/ExceptionTest.scala
@@ -15,7 +15,7 @@ class ExceptionTest extends AnyFlatSpec with Matchers {
 
   "unsupervised" should "throw the exception thrown by a joined fork" in {
     val trail = Trail()
-    try unsupervised(forkUnsupervised(throw CustomException()).join())
+    try unsupervised(forkPlain(throw CustomException()).join())
     catch case e: Exception => trail.add(e.getClass.getSimpleName)
 
     trail.get shouldBe Vector("CustomException")
@@ -116,7 +116,7 @@ class ExceptionTest extends AnyFlatSpec with Matchers {
 
   "joinEither" should "catch the exception with which a fork ends" in {
     val r = supervised {
-      val f = forkUnsupervised {
+      val f = forkPlain {
         throw CustomException()
       }
       f.joinEither()

--- a/core/src/test/scala/ox/ForkTest.scala
+++ b/core/src/test/scala/ox/ForkTest.scala
@@ -11,12 +11,12 @@ class ForkTest extends AnyFlatSpec with Matchers {
   "fork" should "run two forks concurrently" in {
     val trail = Trail()
     scoped {
-      val f1 = fork {
+      val f1 = forkUnsupervised {
         sleep(500.millis)
         trail.add("f1 complete")
         5
       }
-      val f2 = fork {
+      val f2 = forkUnsupervised {
         sleep(1.second)
         trail.add("f2 complete")
         6
@@ -31,8 +31,8 @@ class ForkTest extends AnyFlatSpec with Matchers {
   it should "allow nested forks" in {
     val trail = Trail()
     scoped {
-      val f1 = fork {
-        val f2 = fork {
+      val f1 = forkUnsupervised {
+        val f2 = forkUnsupervised {
           try 6
           finally trail.add("f2 complete")
         }
@@ -50,8 +50,8 @@ class ForkTest extends AnyFlatSpec with Matchers {
   it should "interrupt child forks when parents complete" in {
     val trail = Trail()
     scoped {
-      val f1 = fork {
-        fork {
+      val f1 = forkUnsupervised {
+        forkUnsupervised {
           try
             sleep(1.second)
             trail.add("f2 complete")

--- a/core/src/test/scala/ox/ForkTest.scala
+++ b/core/src/test/scala/ox/ForkTest.scala
@@ -11,12 +11,12 @@ class ForkTest extends AnyFlatSpec with Matchers {
   "fork" should "run two forks concurrently" in {
     val trail = Trail()
     unsupervised {
-      val f1 = forkUnsupervised {
+      val f1 = forkPlain {
         sleep(500.millis)
         trail.add("f1 complete")
         5
       }
-      val f2 = forkUnsupervised {
+      val f2 = forkPlain {
         sleep(1.second)
         trail.add("f2 complete")
         6
@@ -31,8 +31,8 @@ class ForkTest extends AnyFlatSpec with Matchers {
   it should "allow nested forks" in {
     val trail = Trail()
     unsupervised {
-      val f1 = forkUnsupervised {
-        val f2 = forkUnsupervised {
+      val f1 = forkPlain {
+        val f2 = forkPlain {
           try 6
           finally trail.add("f2 complete")
         }
@@ -50,8 +50,8 @@ class ForkTest extends AnyFlatSpec with Matchers {
   it should "interrupt child forks when parents complete" in {
     val trail = Trail()
     unsupervised {
-      val f1 = forkUnsupervised {
-        forkUnsupervised {
+      val f1 = forkPlain {
+        forkPlain {
           try
             sleep(1.second)
             trail.add("f2 complete")

--- a/core/src/test/scala/ox/ForkTest.scala
+++ b/core/src/test/scala/ox/ForkTest.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.*
 class ForkTest extends AnyFlatSpec with Matchers {
   "fork" should "run two forks concurrently" in {
     val trail = Trail()
-    scoped {
+    unsupervised {
       val f1 = forkUnsupervised {
         sleep(500.millis)
         trail.add("f1 complete")
@@ -30,7 +30,7 @@ class ForkTest extends AnyFlatSpec with Matchers {
 
   it should "allow nested forks" in {
     val trail = Trail()
-    scoped {
+    unsupervised {
       val f1 = forkUnsupervised {
         val f2 = forkUnsupervised {
           try 6
@@ -49,7 +49,7 @@ class ForkTest extends AnyFlatSpec with Matchers {
 
   it should "interrupt child forks when parents complete" in {
     val trail = Trail()
-    scoped {
+    unsupervised {
       val f1 = forkUnsupervised {
         forkUnsupervised {
           try

--- a/core/src/test/scala/ox/LocalTest.scala
+++ b/core/src/test/scala/ox/LocalTest.scala
@@ -12,7 +12,7 @@ class LocalTest extends AnyFlatSpec with Matchers {
     val trail = Trail()
     val v = ForkLocal("a")
     scoped {
-      val f1 = fork {
+      val f1 = forkUnsupervised {
         v.scopedWhere("x") {
           sleep(100.millis)
           trail.add(s"In f1 = ${v.get()}")
@@ -20,10 +20,10 @@ class LocalTest extends AnyFlatSpec with Matchers {
         v.get()
       }
 
-      val f3 = fork {
+      val f3 = forkUnsupervised {
         v.scopedWhere("z") {
           sleep(100.millis)
-          fork {
+          forkUnsupervised {
             sleep(100.millis)
             trail.add(s"In f3 = ${v.get()}")
           }.join()
@@ -43,12 +43,12 @@ class LocalTest extends AnyFlatSpec with Matchers {
     val trail = Trail()
     val v = ForkLocal("a")
     scoped {
-      fork {
+      forkUnsupervised {
         v.scopedWhere("x") {
           trail.add(s"nested1 = ${v.get()}")
 
           scoped {
-            fork {
+            forkUnsupervised {
               trail.add(s"nested2 = ${v.get()}")
             }.join()
           }

--- a/core/src/test/scala/ox/LocalTest.scala
+++ b/core/src/test/scala/ox/LocalTest.scala
@@ -12,7 +12,7 @@ class LocalTest extends AnyFlatSpec with Matchers {
     val trail = Trail()
     val v = ForkLocal("a")
     unsupervised {
-      val f1 = forkUnsupervised {
+      val f1 = forkPlain {
         v.unsupervisedWhere("x") {
           sleep(100.millis)
           trail.add(s"In f1 = ${v.get()}")
@@ -20,10 +20,10 @@ class LocalTest extends AnyFlatSpec with Matchers {
         v.get()
       }
 
-      val f3 = forkUnsupervised {
+      val f3 = forkPlain {
         v.unsupervisedWhere("z") {
           sleep(100.millis)
-          forkUnsupervised {
+          forkPlain {
             sleep(100.millis)
             trail.add(s"In f3 = ${v.get()}")
           }.join()
@@ -43,12 +43,12 @@ class LocalTest extends AnyFlatSpec with Matchers {
     val trail = Trail()
     val v = ForkLocal("a")
     unsupervised {
-      forkUnsupervised {
+      forkPlain {
         v.unsupervisedWhere("x") {
           trail.add(s"nested1 = ${v.get()}")
 
           unsupervised {
-            forkUnsupervised {
+            forkPlain {
               trail.add(s"nested2 = ${v.get()}")
             }.join()
           }

--- a/core/src/test/scala/ox/LocalTest.scala
+++ b/core/src/test/scala/ox/LocalTest.scala
@@ -11,9 +11,9 @@ class LocalTest extends AnyFlatSpec with Matchers {
   "fork locals" should "properly propagate values" in {
     val trail = Trail()
     val v = ForkLocal("a")
-    scoped {
+    unsupervised {
       val f1 = forkUnsupervised {
-        v.scopedWhere("x") {
+        v.unsupervisedWhere("x") {
           sleep(100.millis)
           trail.add(s"In f1 = ${v.get()}")
         }
@@ -21,7 +21,7 @@ class LocalTest extends AnyFlatSpec with Matchers {
       }
 
       val f3 = forkUnsupervised {
-        v.scopedWhere("z") {
+        v.unsupervisedWhere("z") {
           sleep(100.millis)
           forkUnsupervised {
             sleep(100.millis)
@@ -42,12 +42,12 @@ class LocalTest extends AnyFlatSpec with Matchers {
   it should "propagate values across multiple scopes" in {
     val trail = Trail()
     val v = ForkLocal("a")
-    scoped {
+    unsupervised {
       forkUnsupervised {
-        v.scopedWhere("x") {
+        v.unsupervisedWhere("x") {
           trail.add(s"nested1 = ${v.get()}")
 
-          scoped {
+          unsupervised {
             forkUnsupervised {
               trail.add(s"nested2 = ${v.get()}")
             }.join()
@@ -61,7 +61,7 @@ class LocalTest extends AnyFlatSpec with Matchers {
     trail.get shouldBe Vector("nested1 = x", "nested2 = x", "outer = a")
   }
 
-  it should "propagate errors from forks created within scoped values" in {
+  it should "propagate errors from forks created within local values" in {
     val v = ForkLocal("v1")
     val caught = intercept[RuntimeException] {
       supervised {

--- a/core/src/test/scala/ox/ParTest.scala
+++ b/core/src/test/scala/ox/ParTest.scala
@@ -55,7 +55,7 @@ class ParTest extends AnyFlatSpec with Matchers {
   "parLimit" should "run up to the given number of computations in parallel" in {
     val running = new AtomicInteger(0)
     val max = new AtomicInteger(0)
-    val result = scoped {
+    val result = unsupervised {
       parLimit(2)(
         (1 to 9).map(i =>
           () => {

--- a/core/src/test/scala/ox/ResourceTest.scala
+++ b/core/src/test/scala/ox/ResourceTest.scala
@@ -9,7 +9,7 @@ class ResourceTest extends AnyFlatSpec with Matchers {
   "useInScope" should "release resources after allocation" in {
     val trail = Trail()
 
-    scoped {
+    unsupervised {
       val r = useInScope { trail.add("allocate"); 1 }(n => trail.add(s"release $n"))
       r shouldBe 1
       trail.get shouldBe Vector("allocate")
@@ -20,7 +20,7 @@ class ResourceTest extends AnyFlatSpec with Matchers {
   it should "release resources in reverse order" in {
     val trail = Trail()
 
-    scoped {
+    unsupervised {
       val r1 = useInScope { trail.add("allocate 1"); 1 }(n => trail.add(s"release $n"))
       val r2 = useInScope { trail.add("allocate 2"); 2 }(n => trail.add(s"release $n"))
       r1 shouldBe 1
@@ -34,7 +34,7 @@ class ResourceTest extends AnyFlatSpec with Matchers {
     val trail = Trail()
 
     try
-      scoped {
+      unsupervised {
         val r1 = useInScope {
           trail.add("allocate 1"); 1
         }(n => trail.add(s"release $n"))
@@ -53,7 +53,7 @@ class ResourceTest extends AnyFlatSpec with Matchers {
     val trail = Trail()
 
     try
-      scoped {
+      unsupervised {
         val r1 = useInScope {
           trail.add("allocate 1");
           1
@@ -79,7 +79,7 @@ class ResourceTest extends AnyFlatSpec with Matchers {
   it should "release registered resources" in {
     val trail = Trail()
 
-    scoped {
+    unsupervised {
       releaseAfterScope(trail.add("release"))
       trail.add("in scope")
     }

--- a/core/src/test/scala/ox/SupervisedTest.scala
+++ b/core/src/test/scala/ox/SupervisedTest.scala
@@ -106,7 +106,7 @@ class SupervisedTest extends AnyFlatSpec with Matchers {
         trail.add("a")
       }
 
-      forkUnsupervised {
+      forkPlain {
         sleep(200.millis)
         throw new RuntimeException("x")
       }

--- a/core/src/test/scala/ox/channels/ChannelTest.scala
+++ b/core/src/test/scala/ox/channels/ChannelTest.scala
@@ -16,10 +16,10 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     s"channel with capacity $capacity" should "send and receive two spaced elements" in {
       val c = Channel.withCapacity[Int](capacity)
       unsupervised {
-        val f1 = forkUnsupervised {
+        val f1 = forkPlain {
           c.receive()
         }
-        val f2 = forkUnsupervised {
+        val f2 = forkPlain {
           c.receive()
         }
 
@@ -41,11 +41,11 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
       unsupervised {
         val fs = (1 to 2 * n).map { i =>
           if i % 2 == 0 then
-            forkUnsupervised {
+            forkPlain {
               c.send(i / 2); 0
             }
           else
-            forkUnsupervised {
+            forkPlain {
               c.receive()
             }
         }
@@ -77,13 +77,13 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
       unsupervised {
         cs.foreach { c =>
           (1 to n).foreach { i =>
-            forkUnsupervised(c.send(i))
+            forkPlain(c.send(i))
           }
         }
 
         val result = new AtomicInteger(0)
 
-        forkUnsupervised {
+        forkPlain {
           forever {
             result.addAndGet(select(cs.map(_.receiveClause)).value).discard
           }
@@ -102,7 +102,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
       val cs = (1 to cn).map(_ => Channel.withCapacity[Int](capacity)).toList
       unsupervised {
         cs.foreach { c =>
-          forkUnsupervised {
+          forkPlain {
             (1 to n).foreach(c.send)
             sleep(10.millis)
             c.done()
@@ -111,7 +111,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
 
         val result = new ConcurrentLinkedQueue[Int | ChannelClosed]()
 
-        forkUnsupervised {
+        forkPlain {
           var loop = true
           while loop do {
             val r = selectSafe(cs.map(_.receiveClause))
@@ -171,7 +171,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
       val c1 = Channel.withCapacity[Int](capacity)
       val c2 = Channel.withCapacity[Int](capacity)
       unsupervised {
-        forkUnsupervised {
+        forkPlain {
           c1.send(1)
           c2.done()
         }
@@ -185,7 +185,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
       val c1 = Channel.withCapacity[Int](capacity)
       val c2 = Channel.withCapacity[Int](capacity)
       unsupervised {
-        forkUnsupervised {
+        forkPlain {
           c2.done()
         }
 
@@ -198,7 +198,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
       val c1 = Channel.withCapacity[Int](capacity)
       val c2 = Channel.withCapacity[Int](capacity)
       unsupervised {
-        forkUnsupervised {
+        forkPlain {
           sleep(100.millis) // let the select block
           c2.done()
         }
@@ -243,15 +243,15 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     val c = Channel.rendezvous[String]
     val trail = ConcurrentLinkedQueue[String]()
     unsupervised {
-      forkUnsupervised {
+      forkPlain {
         c.send("x")
         trail.add("S")
       }
-      forkUnsupervised {
+      forkPlain {
         c.send("y")
         trail.add("S")
       }
-      val f3 = forkUnsupervised {
+      val f3 = forkPlain {
         sleep(100.millis)
         trail.add("R1")
         val r1 = c.receive()
@@ -273,11 +273,11 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     val c2 = Channel.rendezvous[Int]
 
     unsupervised {
-      val f1 = forkUnsupervised(c1.receive())
+      val f1 = forkPlain(c1.receive())
       select(c1.sendClause(1), c2.sendClause(2))
       f1.join() shouldBe 1
 
-      val f2 = forkUnsupervised(c2.receive())
+      val f2 = forkPlain(c2.receive())
       select(c1.sendClause(1), c2.sendClause(2))
       f2.join() shouldBe 2
     }
@@ -288,11 +288,11 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     val c2 = Channel.rendezvous[Int]
 
     unsupervised {
-      val f1 = forkUnsupervised(c1.receive())
+      val f1 = forkPlain(c1.receive())
       select(c1.sendClause(1), c2.receiveClause) shouldBe c1.Sent()
       f1.join() shouldBe 1
 
-      val f2 = forkUnsupervised(c2.send(2))
+      val f2 = forkPlain(c2.send(2))
       select(c1.sendClause(1), c2.receiveClause) shouldBe c2.Received(2)
       f2.join() shouldBe ()
     }

--- a/core/src/test/scala/ox/channels/ChannelTest.scala
+++ b/core/src/test/scala/ox/channels/ChannelTest.scala
@@ -15,7 +15,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
   List(0, 1, 2, 100, 10000).foreach { capacity =>
     s"channel with capacity $capacity" should "send and receive two spaced elements" in {
       val c = Channel.withCapacity[Int](capacity)
-      scoped {
+      unsupervised {
         val f1 = forkUnsupervised {
           c.receive()
         }
@@ -38,7 +38,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     it should "send and receive many elements, with concurrent senders & receivers" in {
       val n = 10000
       val c = Channel.withCapacity[Int](capacity)
-      scoped {
+      unsupervised {
         val fs = (1 to 2 * n).map { i =>
           if i % 2 == 0 then
             forkUnsupervised {
@@ -74,7 +74,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
       val cn = 10
 
       val cs = (1 to cn).map(_ => Channel.withCapacity[Int](capacity)).toList
-      scoped {
+      unsupervised {
         cs.foreach { c =>
           (1 to n).foreach { i =>
             forkUnsupervised(c.send(i))
@@ -100,7 +100,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
       val cn = 10
 
       val cs = (1 to cn).map(_ => Channel.withCapacity[Int](capacity)).toList
-      scoped {
+      unsupervised {
         cs.foreach { c =>
           forkUnsupervised {
             (1 to n).foreach(c.send)
@@ -170,7 +170,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     it should "select from a non-done channel, if a value is immediately available" in {
       val c1 = Channel.withCapacity[Int](capacity)
       val c2 = Channel.withCapacity[Int](capacity)
-      scoped {
+      unsupervised {
         forkUnsupervised {
           c1.send(1)
           c2.done()
@@ -184,7 +184,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     it should "select a done channel, when the channel is done immediately" in {
       val c1 = Channel.withCapacity[Int](capacity)
       val c2 = Channel.withCapacity[Int](capacity)
-      scoped {
+      unsupervised {
         forkUnsupervised {
           c2.done()
         }
@@ -197,7 +197,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     it should "select a done channel, when the channel becomes done" in {
       val c1 = Channel.withCapacity[Int](capacity)
       val c2 = Channel.withCapacity[Int](capacity)
-      scoped {
+      unsupervised {
         forkUnsupervised {
           sleep(100.millis) // let the select block
           c2.done()
@@ -242,7 +242,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
   "rendezvous channel" should "wait until elements are transmitted" in {
     val c = Channel.rendezvous[String]
     val trail = ConcurrentLinkedQueue[String]()
-    scoped {
+    unsupervised {
       forkUnsupervised {
         c.send("x")
         trail.add("S")
@@ -272,7 +272,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     val c1 = Channel.rendezvous[Int]
     val c2 = Channel.rendezvous[Int]
 
-    scoped {
+    unsupervised {
       val f1 = forkUnsupervised(c1.receive())
       select(c1.sendClause(1), c2.sendClause(2))
       f1.join() shouldBe 1
@@ -287,7 +287,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     val c1 = Channel.rendezvous[Int]
     val c2 = Channel.rendezvous[Int]
 
-    scoped {
+    unsupervised {
       val f1 = forkUnsupervised(c1.receive())
       select(c1.sendClause(1), c2.receiveClause) shouldBe c1.Sent()
       f1.join() shouldBe 1
@@ -328,7 +328,7 @@ class ChannelTest extends AnyFlatSpec with Matchers with Eventually {
     for (i <- 1 to 100) {
       info(s"iteration $i")
 
-      scoped {
+      unsupervised {
         // given
         val c = Channel.buffered[Int](3)
         c.send(1)

--- a/doc/adr/0006-actors.md
+++ b/doc/adr/0006-actors.md
@@ -1,4 +1,4 @@
-# 5. Application errors
+# 6. Actors
 
 Date: 2024-03-26
 

--- a/doc/adr/0007-supervised-unsupervised-scopes.md
+++ b/doc/adr/0007-supervised-unsupervised-scopes.md
@@ -1,0 +1,27 @@
+# 7. Supervised & unsupervised scopes
+
+Date: 2024-04-17
+
+## Context
+
+Originally, ox had only `scoped` which created non-supervised scopes, that is errors were only discovered via explicit
+joining. This was later changed by introducing `supervised` and `unsupervised` scopes, where the former would end
+immediately when any fork failed, and the latter would not. However, `supervised` scopes have an overhead: they create
+an additional fork, in which the scope's main body is run. Is it possible to avoid this extra fork?
+
+## Decision
+
+In short: no.
+
+An alternate design would be to store the thread, that created the scope as part of the supervisor, and when any 
+exception occurs, interrupt that thread so that it would discover the exception. However, this would be prone to
+interruption-races with external interruptions of that main thread. Even if we included an additional flag, specifying
+if the interruption happened because the scope ends, it would still be possible for an external interrupt to go
+unnoticed (if it happened at the same time, as the internal one). Even though unlikely, such a design would be fragile, 
+hence we are keeping the current implementation.
+
+## Consequences
+
+To make our design more type-safe, we split the `Ox` capability into `OxPlain` (allowing only unsupervised forks), and
+`Ox`. The `plain` nomeclature was chosen to indicate that the scope is unsupervised, however `forkPlain` is much shorter 
+than e.g. `forkUnsupervised`. Hence introducing a new name seems justified.

--- a/doc/dictionary.md
+++ b/doc/dictionary.md
@@ -19,8 +19,8 @@ Fork lifecycle:
 * then, forks **complete**: either a fork **succeeds** with a value, or a fork **fails** with an exception
 * external **cancellation** (`Fork.cancel()`) interrupts the fork and waits until it completes; interruption uses
   JVM's mechanism of injecting an `InterruptedException`
-* forks are **supervised** if they are run in a `supervised` scope, and not unsupervised (started using 
-  `forkUnsupervised` or `forkCancellable`)
+* forks are **supervised** if they are run in a `supervised` scope, and not unsupervised (started using `forkPlain` or 
+  `forkCancellable`)
 
 Scope lifecycle:
 * a scope **ends**: when unsupervised, the scope's body is entirely evaluated; when supervised, all user (non-daemon) &

--- a/doc/dictionary.md
+++ b/doc/dictionary.md
@@ -4,8 +4,9 @@ How we use various terms throughout the codebase and the documentation (or at le
 
 Scopes:
 * **concurrency scope**: either `supervised` (default), `supervisedError` (permitting application errors), 
-  or `scoped` ("advanced")
-* scope **body**: the code block passed to a concurrency scope (the `supervised` or `scoped` method)
+  or `unsupervised`
+* scope **body**: the code block passed to a concurrency scope (the `supervised`, `supervisedError` or `unsupervised` 
+  method)
 
 Fork lifecycle:
 * within scopes, asynchronously running **forks** can be **started**
@@ -20,8 +21,8 @@ Scope lifecycle:
 * a scope **ends**: when unsupervised, the scope's body is entirely evaluated; when supervised, all user (non-daemon) &
   supervised forks complete successfully, or at least one user/daemon supervised fork fails, or an application error
   is reported. When the scope ends, all forks that are still running are cancelled
-* scope **completes**, once all forks complete and finalizers are run; then, the `supervised` or `scoped`
-  method returns.
+* scope **completes**, once all forks complete and finalizers are run; then, the `supervised`, `supervisedErro` or 
+  `unsupervised` method returns.
 
 Errors:
 * fork **failure**: when a fork fails with an exception

--- a/doc/dictionary.md
+++ b/doc/dictionary.md
@@ -8,6 +8,11 @@ Scopes:
 * scope **body**: the code block passed to a concurrency scope (the `supervised`, `supervisedError` or `unsupervised` 
   method)
 
+Types of forks:
+* supervised / plain (unsupervised)
+* daemon / user
+* optionally, recognizing application errors
+
 Fork lifecycle:
 * within scopes, asynchronously running **forks** can be **started**
 * after being started a fork is **running**

--- a/doc/error-handling-scopes.md
+++ b/doc/error-handling-scopes.md
@@ -55,5 +55,5 @@ inspected.
 
 ## Unsupervised scopes
 
-In an unsupervised scope (created using `scoped`), failures of the forks won't be reported in any way, unless they
+In an unsupervised scope (created using `unsupervised`), failures of the forks won't be reported in any way, unless they
 are explicitly joined. Hence, if there's no `Fork.join`, the exception might go unnoticed.

--- a/doc/fork-join.md
+++ b/doc/fork-join.md
@@ -6,12 +6,12 @@ these cases, threads can be started using the structured concurrency APIs descri
 Forks (new threads) can only be started within a **concurrency scope**. Such a scope is defined using the `supervised`,
 `supervisedError` or `scoped` methods.
 
-The lifetime of the forks is defined by the structure of the code, and corresponds to the enclosing `supervised` or
-`scoped` block. Once the code block passed to the scope completes, any forks that are still running are interrupted.
-The whole block will complete only once all forks have completed (successfully, or with an exception).
+The lifetime of the forks is defined by the structure of the code, and corresponds to the enclosing `supervised`, 
+`supervisedError` or `scoped` block. Once the code block passed to the scope completes, any forks that are still running 
+are interrupted. The whole block will complete only once all forks have completed (successfully, or with an exception).
 
-Hence, it is guaranteed that all forks started within `supervised` or `scoped` will finish successfully, with an
-exception, or due to an interrupt.
+Hence, it is guaranteed that all forks started within `supervised`, `supervisedError` or `scoped` will finish 
+successfully, with an exception, or due to an interrupt.
 
 For example, the code below is equivalent to `par`:
 
@@ -34,8 +34,8 @@ supervised {
 }
 ```
 
-It is a compile-time error to use `fork`/`forkUser` outside of a `supervised` or `scoped` block. Helper methods might
-require to be run within a scope by requiring the `Ox` capability:
+It is a compile-time error to use `fork`/`forkUser` outside of a `supervised` block. Helper methods might require to be 
+run within a scope by requiring the `Ox` capability:
 
 ```scala mdoc:compile-only
 import ox.{fork, Fork, Ox, sleep, supervised}

--- a/doc/fork-join.md
+++ b/doc/fork-join.md
@@ -35,8 +35,8 @@ supervised {
 }
 ```
 
-It is a compile-time error to use `fork`/`forkUser` outside of a `supervised` block. Helper methods might require to be 
-run within a scope by requiring the `Ox` capability:
+It is a compile-time error to use any of the `fork` methods outside of a `supervised` block. Helper methods might 
+require to be run within a scope by requiring the `Ox` capability:
 
 ```scala mdoc:compile-only
 import ox.{fork, Fork, Ox, sleep, supervised}
@@ -68,7 +68,7 @@ Scopes can be arbitrarily nested.
 ## Supervision
 
 The default scope, created with `supervised`, watches over the forks that are started within. Any forks started with
-`fork` and `forkUser` are by default supervised.
+`fork`, `forkUser`, `forkError` and `forUserError` are by default supervised.
 
 This means that the scope will end only when either:
 
@@ -99,24 +99,27 @@ supervised {
 
 ## User, daemon and unsupervised forks
 
-In supervised scopes, forks created using `fork` behave as daemon threads. That is, their failure ends the scope, but
-the scope will also end once the body and all user forks succeed, regardless if the (daemon) fork is still running.
+Forks created using `fork` behave as daemon threads. That is, their failure ends the scope, but the scope will also end 
+once the body and all user forks succeed, regardless if the (daemon) fork is still running.
 
 Alternatively, a user fork can be created using `forkUser`. Such a fork is required to complete successfully, in order
 for the scope to end successfully. Hence, when the body of the scope completes, the scope will wait until all user
 forks have completed as well.
 
-Finally, entirely unsupervised forks can be started using `forkUnsupervised`.
+Finally, entirely unsupervised forks can be started using `forkPlain`.
 
 ## Unsupervised scopes
 
-An unsupervised scope can be created using `unsupervised`. Within such scopes, only `forkUnsupervised` and 
-`forkCancellable` forks can be started.
+An unsupervised scope can be created using `unsupervised`. Within such scopes, only `forkPlain` and `forkCancellable` 
+forks can be started.
 
 Such a scope ends, once the code block passed to `unsupervised` completes. Then, all running forks are cancelled. Still, 
 the scope completes (that is, the `unsupervised` block returns) only once all forks have completed.
 
 Fork failures aren't handled in any special way, and can be inspected using the `Fork.join()` method.
+
+For helper method, the capability that needs to be passed is `OxPlain`, a subtype of `Ox` that only allows starting
+unsupervised forks.
 
 ## Cancelling forks
 

--- a/doc/fork-join.md
+++ b/doc/fork-join.md
@@ -4,13 +4,14 @@ It's safest to use higher-level methods, such as `par` or `race`, however this i
 these cases, threads can be started using the structured concurrency APIs described below.
 
 Forks (new threads) can only be started within a **concurrency scope**. Such a scope is defined using the `supervised`,
-`supervisedError` or `scoped` methods.
+`supervisedError` or `unsupervised` methods.
 
 The lifetime of the forks is defined by the structure of the code, and corresponds to the enclosing `supervised`, 
-`supervisedError` or `scoped` block. Once the code block passed to the scope completes, any forks that are still running 
-are interrupted. The whole block will complete only once all forks have completed (successfully, or with an exception).
+`supervisedError` or `unsupervised` block. Once the code block passed to the scope completes, any forks that are still 
+running are interrupted. The whole block will complete only once all forks have completed (successfully, or with an 
+exception).
 
-Hence, it is guaranteed that all forks started within `supervised`, `supervisedError` or `scoped` will finish 
+Hence, it is guaranteed that all forks started within `supervised`, `supervisedError` or `unsupervised` will finish 
 successfully, with an exception, or due to an interrupt.
 
 For example, the code below is equivalent to `par`:
@@ -100,11 +101,11 @@ Finally, entirely unsupervised forks can be started using `forkUnsupervised`.
 
 ## Unsupervised scopes
 
-An unsupervised scope can be created using `scoped`. Any forks started within are unsupervised. This is considered an
-advanced feature, and should be used with caution.
+An unsupervised scope can be created using `unsupervised`. Within such scopes, only `forkUnsupervised` and 
+`forkCancellable` forks can be started.
 
-Such a scope ends, once the code block passed to `scoped` completes. Then, all running forks are cancelled. Still, the
-scope completes (that is, the `scoped` block returns) only once all forks have completed.
+Such a scope ends, once the code block passed to `unsupervised` completes. Then, all running forks are cancelled. Still, 
+the scope completes (that is, the `unsupervised` block returns) only once all forks have completed.
 
 Fork failures aren't handled in any special way, and can be inspected using the `Fork.join()` method.
 

--- a/doc/fork-join.md
+++ b/doc/fork-join.md
@@ -56,6 +56,15 @@ supervised {
 
 Scopes can be arbitrarily nested.
 
+## Types of forks - summary
+
+* `fork`: supervised, daemon fork
+* `forkUser`: supervised, user fork (scope will wait for it to complete, if there are no other errors)
+* `forkError`: supervised, daemon fork, which is allowed to fail with an application error
+* `forkUserError`: supervised, user fork, which is allowed to fail with an application error
+* `forkPlain`: unsupervised fork
+* `forkCancellable`: unsupervised, cancellable fork
+
 ## Supervision
 
 The default scope, created with `supervised`, watches over the forks that are started within. Any forks started with

--- a/doc/fork-local.md
+++ b/doc/fork-local.md
@@ -48,7 +48,7 @@ will use the provided instance, not the outer one. E.g.:
 ```scala 
 def withSpan[T](spanName: String)(f: Ox ?=> T): T =
   val span = spanBuilder.startSpan(spanName)
-  currentSpan.scopedWhere(Some(span)) {
+  currentSpan.supervisedWhere(Some(span)) {
     try f
     finally span.end()
   }

--- a/kafka/src/main/scala/ox/kafka/KafkaStage.scala
+++ b/kafka/src/main/scala/ox/kafka/KafkaStage.scala
@@ -77,7 +77,7 @@ object KafkaStage:
       fork {
         try
           // starting a nested scope, so that the committer is interrupted when the main process ends (when there's an exception)
-          scoped {
+          unsupervised {
             // committer
             val commitDoneSource =
               if commitOffsets then Source.fromFork(fork(doCommit(toCommit).tapException(e => c.errorSafe(e).discard))) else Source.empty


### PR DESCRIPTION
This introduced a hierarchy of capabilities: `OxPlain >: Ox >: OxError`. `OxPlain` allows starting only unsupervised forks, and is granted by `unsupervised` scope creation.