### PR TITLE
add ability to combine Schedules for retries

### DIFF
--- a/core/src/main/scala/ox/resilience/Schedule.scala
+++ b/core/src/main/scala/ox/resilience/Schedule.scala
@@ -10,6 +10,8 @@ object Schedule:
 
   private[resilience] sealed trait Finite extends Schedule:
     def maxRetries: Int
+    def fallbackTo(fallback: Finite): Finite = Combination(this, fallback)
+    def fallbackTo(fallback: Infinite): Infinite = Combination.forever(this, fallback)
 
   private[resilience] sealed trait Infinite extends Schedule
 
@@ -137,7 +139,3 @@ object Schedule:
     def forever(base: Finite, fallback: Infinite): Infinite = CombinationForever(base, fallback)
 
   case class CombinationForever private[resilience](base: Finite, fallback: Infinite) extends Combined, Infinite
-
-  extension (schedule: Finite)
-    def fallbackTo(fallback: Finite): Finite = Combination(schedule, fallback)
-    def fallbackTo(fallback: Infinite): Infinite = Combination.forever(schedule, fallback)

--- a/core/src/main/scala/ox/resilience/Schedule.scala
+++ b/core/src/main/scala/ox/resilience/Schedule.scala
@@ -119,8 +119,8 @@ object Schedule:
       Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)
 
   private[resilience] sealed trait Combined extends Schedule:
-    val base: Finite
-    val fallback: Schedule
+    def base: Finite
+    def fallback: Schedule
     override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
       if base.maxRetries > attempt then base.nextDelay(attempt, lastDelay)
       else fallback.nextDelay(attempt - base.maxRetries, lastDelay)

--- a/core/src/main/scala/ox/resilience/Schedule.scala
+++ b/core/src/main/scala/ox/resilience/Schedule.scala
@@ -10,8 +10,8 @@ object Schedule:
 
   private[resilience] sealed trait Finite extends Schedule:
     def maxRetries: Int
-    def fallbackTo(fallback: Finite): Finite = Combination(this, fallback)
-    def fallbackTo(fallback: Infinite): Infinite = Combination.forever(this, fallback)
+    def fallbackTo(fallback: Finite): Finite = FallingBack(this, fallback)
+    def fallbackTo(fallback: Infinite): Infinite = FallingBack.forever(this, fallback)
 
   private[resilience] sealed trait Infinite extends Schedule
 
@@ -120,7 +120,7 @@ object Schedule:
     override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
       Backoff.nextDelay(attempt, initialDelay, maxDelay, jitter, lastDelay)
 
-  private[resilience] sealed trait Combined extends Schedule:
+  private[resilience] sealed trait WithFallback extends Schedule:
     def base: Finite
     def fallback: Schedule
     override def nextDelay(attempt: Int, lastDelay: Option[FiniteDuration]): FiniteDuration =
@@ -130,12 +130,12 @@ object Schedule:
   /** A schedule that combines two schedules, using [[base]] first [[base.maxRetries]] number of times, and then using [[fallback]]
     * [[fallback.maxRetries]] number of times.
     */
-  case class Combination(base: Finite, fallback: Finite) extends Combined, Finite:
+  case class FallingBack(base: Finite, fallback: Finite) extends WithFallback, Finite:
     override def maxRetries: Int = base.maxRetries + fallback.maxRetries
 
-  object Combination:
+  object FallingBack:
     /** A schedule that retries indefinitely, using [[base]] first [[base.maxRetries]] number of times, and then always using [[fallback]].
       */
-    def forever(base: Finite, fallback: Infinite): Infinite = CombinationForever(base, fallback)
+    def forever(base: Finite, fallback: Infinite): Infinite = FallingBackForever(base, fallback)
 
-  case class CombinationForever private[resilience](base: Finite, fallback: Infinite) extends Combined, Infinite
+  case class FallingBackForever private[resilience] (base: Finite, fallback: Infinite) extends WithFallback, Infinite

--- a/core/src/test/scala/ox/resilience/ScheduleCombinationRetryTest.scala
+++ b/core/src/test/scala/ox/resilience/ScheduleCombinationRetryTest.scala
@@ -1,0 +1,52 @@
+package ox.resilience
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.ElapsedTime
+
+import scala.concurrent.duration.*
+
+class ScheduleCombinationRetryTest extends AnyFlatSpec with Matchers with ElapsedTime:
+  behavior of "retry with combination of schedules"
+
+  it should "retry 3 times immediately and then 2 times with delay" in {
+    // given
+    var counter = 0
+    val sleep = 100.millis
+    val immediateRetries = 3
+    val delayedRetries = 2
+
+    def f =
+      counter += 1
+      throw new RuntimeException("boom")
+
+    val schedule = Schedule.Immediate(immediateRetries).fallbackTo(Schedule.Delay(delayedRetries, sleep))
+
+    // when
+    val (result, elapsedTime) = measure(the[RuntimeException] thrownBy retry(RetryPolicy(schedule))(f))
+
+    // then
+    result should have message "boom"
+    counter shouldBe immediateRetries + delayedRetries + 1
+    elapsedTime.toMillis should be >= 2 * sleep.toMillis
+  }
+
+  it should "retry forever" in {
+    // given
+    var counter = 0
+    val retriesUntilSuccess = 1_000
+    val successfulResult = 42
+
+    def f =
+      counter += 1
+      if counter <= retriesUntilSuccess then throw new RuntimeException("boom") else successfulResult
+
+    val schedule = Schedule.Immediate(100).fallbackTo(Schedule.Delay.forever(2.millis))
+
+    // when
+    val result = retry(RetryPolicy(schedule))(f)
+
+    // then
+    result shouldBe successfulResult
+    counter shouldBe retriesUntilSuccess + 1
+  }

--- a/core/src/test/scala/ox/resilience/ScheduleFallingBackRetryTest.scala
+++ b/core/src/test/scala/ox/resilience/ScheduleFallingBackRetryTest.scala
@@ -6,7 +6,7 @@ import ox.ElapsedTime
 
 import scala.concurrent.duration.*
 
-class ScheduleCombinationRetryTest extends AnyFlatSpec with Matchers with ElapsedTime:
+class ScheduleFallingBackRetryTest extends AnyFlatSpec with Matchers with ElapsedTime:
   behavior of "retry with combination of schedules"
 
   it should "retry 3 times immediately and then 2 times with delay" in {


### PR DESCRIPTION
#58 

I tried to make proposed syntax: 
```scala
val policy: RetryPolicy = RetryPolicy.immediate(3).fallbackTo(RetryPolicy.backoffForever(100.millis))
```
but found `fallbackTo` method on `RetryPolicy` a bit misleading, because with current design of retry classes we cannot easily compose different `ResultPolicy` and `onRetry` functions. Instead, I decided to make composable just `Schedule` classes.

I added `Combination` and `CombinationForever` subclasses by analogy so we can combine `Finite` schedules with both `Finite` and `Infinite` fallbacks, but I have a feeling that they add an unreasonable complication :thinking: - feel free to reject it 

P.S. it's my first opensource request