### PR TITLE
Add text .encode .decode operators (UTF-8)

### DIFF
--- a/core/src/main/scala/ox/channels/SourceTextOps.scala
+++ b/core/src/main/scala/ox/channels/SourceTextOps.scala
@@ -159,10 +159,10 @@ trait SourceTextOps[+T]:
       outer.receiveOrClosed() match
         // end of channel before getting enough bytes to resolve BOM, assuming no BOM
         case ChannelClosed.Done =>
-          if (buffer == null) then outputChannel.done()
-          else
-            // There's already a buffer accumulated (not BOM), decode it directly
+          if (buffer != null) then 
+            // There's a buffer accumulated (not BOM), decode it directly
             outputChannel.send(buffer.asStringUtf8)
+          outputChannel.done()
         case ChannelClosed.Error(err) =>
           outputChannel.error(err)
         case bytes: T @unchecked =>

--- a/core/src/main/scala/ox/channels/SourceTextOps.scala
+++ b/core/src/main/scala/ox/channels/SourceTextOps.scala
@@ -1,17 +1,24 @@
 package ox.channels
 
 import ox.*
+
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import scala.annotation.tailrec
 
 trait SourceTextOps[+T]:
   outer: Source[T] =>
 
-  /**
-      * Transforms a Source of byte chunks such that each emitted `String` is a text line from the input.
-      *
-      * @return a Source emitting lines read from the input byte chunks, assuming they represent text.
-      */
-  def lines(using Ox, T <:< Chunk[Byte]): Source[String] =
+  private val bomUtf8: Chunk[Byte] = Chunk.fromArray(Array[Byte](-17, -69, -65))
+
+  /** Transforms a Source of byte chunks such that each emitted `String` is a text line from the input.
+    *
+    * @param charset
+    *   the charset to use for decoding the bytes into text.
+    * @return
+    *   a Source emitting lines read from the input byte chunks, assuming they represent text.
+    */
+  def lines(charset: Charset)(using Ox, T <:< Chunk[Byte]): Source[String] =
     // buffer == null is a special state for handling empty chunks in onComplete, in order to tell them apart from empty lines
     outer
       .mapStatefulConcat(() => null: Chunk[Byte])(
@@ -32,4 +39,144 @@ trait SourceTextOps[+T]:
         },
         onComplete = buf => if buf != null then Some(buf) else None
       )
-      .mapAsView(_.asString)
+      .mapAsView(_.asString(charset))
+
+  /** Transforms a Source of byte chunks such that each emitted `String` is a text line from the input decoded using UTF-8 charset.
+    *
+    * @return
+    *   a Source emitting lines read from the input byte chunks, assuming they represent text.
+    */
+  def linesUtf8(using Ox, T <:< Chunk[Byte]): Source[String] =
+    lines(StandardCharsets.UTF_8)
+
+    /** Decodes a stream of chunks of bytes into UTF-8 Strings. This function is able to handle UTF-8 characters encoded on multiple bytes
+      * that are split across chunks.
+      *
+      * @return
+      *   a source of Strings decoded from incoming bytes.
+      */
+    // TODO check for possible exceptions and add error handling
+  def decodeStringUtf8(using Ox, T <:< Chunk[Byte]): Source[String] =
+    val bomSize = 3 // const for UTF-8
+
+    // The general algorithm and some helper functions (with their comments) are copied from fs2: see fs2.text.decodeC
+    // https://github.com/typelevel/fs2/blob/9b1b27cf7a8d7027df852d890555b341da70ef9e/core/shared/src/main/scala/fs2/text.scala
+
+    /*
+     * Copied from fs2 (fs2.text.decodeC.continuationBytes)
+     * Returns the number of continuation bytes if `b` is an ASCII byte or a
+     * leading byte of a multi-byte sequence, and -1 otherwise.
+     */
+    def continuationBytes(b: Byte): Int =
+      if ((b & 0x80) == 0x00) 0 // ASCII byte
+      else if ((b & 0xe0) == 0xc0) 1 // leading byte of a 2 byte seq
+      else if ((b & 0xf0) == 0xe0) 2 // leading byte of a 3 byte seq
+      else if ((b & 0xf8) == 0xf0) 3 // leading byte of a 4 byte seq
+      else -1 // continuation byte or garbage
+
+    /*
+     * Copied from fs2 (fs2.text.decodeC.lastIncompleteBytes)
+     * Returns the length of an incomplete multi-byte sequence at the end of
+     * `bs`. If `bs` ends with an ASCII byte or a complete multi-byte sequence,
+     * 0 is returned.
+     */
+    def lastIncompleteBytes(bs: Array[Byte]): Int = {
+      /*
+       * This is logically the same as this
+       * code, but written in a low level way
+       * to avoid any allocations and just do array
+       * access
+       *
+       *
+       *
+        val lastThree = bs.drop(0.max(bs.size - 3)).toArray.reverseIterator
+        lastThree
+          .map(continuationBytes)
+          .zipWithIndex
+          .find {
+            case (c, _) => c >= 0
+          }
+          .map {
+            case (c, i) => if (c == i) 0 else i + 1
+          }
+          .getOrElse(0)
+
+       */
+
+      val minIdx = 0.max(bs.length - 3)
+      var idx = bs.length - 1
+      var counter = 0
+      var res = 0
+      while (minIdx <= idx) {
+        val c = continuationBytes(bs(idx))
+        if (c >= 0) {
+          if (c != counter)
+            res = counter + 1
+          // exit the loop
+          return res
+        }
+        idx = idx - 1
+        counter = counter + 1
+      }
+      res
+    }
+
+    def processSingleChunk(buffer: Chunk[Byte], nextBytes: Chunk[Byte]): (String, Chunk[Byte]) =
+      // if processing ASCII or largely ASCII buffer is often empty
+      val allBytes: Array[Byte] =
+        if buffer.isEmpty then nextBytes.toArray
+        else Array.concat(buffer.toArray, nextBytes.toArray)
+
+      val splitAt = allBytes.length - lastIncompleteBytes(allBytes)
+      if splitAt == allBytes.length then
+        // in the common case of ASCII chars
+        // we are in this branch so the next buffer will
+        // be empty
+        (new String(allBytes, StandardCharsets.UTF_8), Chunk.empty)
+      else if splitAt == 0 then (null, Chunk.fromArray(allBytes))
+      else (new String(allBytes.take(splitAt), StandardCharsets.UTF_8), Chunk.fromArray(allBytes.drop(splitAt)))
+
+    @tailrec
+    def doPull(buffer: Chunk[Byte], outputChannel: Channel[String]): Unit =
+      outer.receiveOrClosed() match
+        case ChannelClosed.Done if buffer.nonEmpty =>
+          outputChannel.send(buffer.asStringUtf8)
+          outputChannel.done()
+        case ChannelClosed.Done =>
+          outputChannel.done()
+        case ChannelClosed.Error(err) =>
+          outputChannel.error(err)
+        case bytes: T @unchecked =>
+          val (str, newBuf) = processSingleChunk(buffer, bytes)
+          if str != null then outputChannel.send(str)
+          doPull(newBuf, outputChannel)
+
+    def processByteOrderMark(buffer: Chunk[Byte], outputChannel: Channel[String]): Unit =
+      outer.receiveOrClosed() match
+        // end of channel before getting enough bytes to resolve BOM, assuming no BOM
+        case ChannelClosed.Done =>
+          if (buffer == null) then outputChannel.done()
+          else
+            // There's already a buffer accumulated (not BOM), decode it directly
+            outputChannel.send(buffer.asStringUtf8)
+        case ChannelClosed.Error(err) =>
+          outputChannel.error(err)
+        case bytes: T @unchecked =>
+          // A common case, worth checking in advance
+          if buffer == null && bytes.length >= bomSize && !bytes.startsWith(bomUtf8) then doPull(bytes, outputChannel)
+          else
+            val newBuffer0 = if buffer == null then Chunk.empty[Byte] else buffer
+            val newBuffer = newBuffer0 ++ bytes
+            if (newBuffer.length >= bomSize) then
+              val rem = if newBuffer.startsWith(bomUtf8) then newBuffer.drop(bomSize) else newBuffer
+              doPull(rem, outputChannel)
+            else if (newBuffer.startsWith(bomUtf8.take(newBuffer.length))) then
+              processByteOrderMark(newBuffer, outputChannel) // we've accumulated less than the full BOM, let's pull some more
+            else // We've accumulated less than BOM size but we already know that these bytes aren't BOM
+              doPull(newBuffer, outputChannel)
+
+    val outputChannel = Channel.bufferedDefault[String]
+    fork {
+      processByteOrderMark(null, outputChannel)
+    }
+    outputChannel

--- a/core/src/main/scala/ox/channels/SourceTextOps.scala
+++ b/core/src/main/scala/ox/channels/SourceTextOps.scala
@@ -49,13 +49,17 @@ trait SourceTextOps[+T]:
   def linesUtf8(using Ox, T <:< Chunk[Byte]): Source[String] =
     lines(StandardCharsets.UTF_8)
 
-    /** Decodes a stream of chunks of bytes into UTF-8 Strings. This function is able to handle UTF-8 characters encoded on multiple bytes
-      * that are split across chunks.
-      *
-      * @return
-      *   a source of Strings decoded from incoming bytes.
-      */
-    // TODO check for possible exceptions and add error handling
+  /** Encodes a source of `String` in to a source of bytes using UTF-8. */
+  def encodeUtf8(using Ox, T <:< String): Source[Chunk[Byte]] =
+    outer.mapAsView(s => Chunk.fromArray(s.getBytes(StandardCharsets.UTF_8)))
+
+  /** Decodes a stream of chunks of bytes into UTF-8 Strings. This function is able to handle UTF-8 characters encoded on multiple bytes
+    * that are split across chunks.
+    *
+    * @return
+    *   a source of Strings decoded from incoming bytes.
+    */
+  // TODO check for possible exceptions and add error handling
   def decodeStringUtf8(using Ox, T <:< Chunk[Byte]): Source[String] =
     val bomSize = 3 // const for UTF-8
 

--- a/core/src/main/scala/ox/channels/SourceTextOps.scala
+++ b/core/src/main/scala/ox/channels/SourceTextOps.scala
@@ -59,7 +59,6 @@ trait SourceTextOps[+T]:
     * @return
     *   a source of Strings decoded from incoming bytes.
     */
-  // TODO check for possible exceptions and add error handling
   def decodeStringUtf8(using Ox, T <:< Chunk[Byte]): Source[String] =
     val bomSize = 3 // const for UTF-8
 

--- a/core/src/test/scala/ox/channels/SourceCompanionIOOpsTest.scala
+++ b/core/src/test/scala/ox/channels/SourceCompanionIOOpsTest.scala
@@ -12,7 +12,6 @@ import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Paths
 import java.io.IOException
-import scala.io.StdIn
 
 class SourceCompanionIOOpsTest extends AnyWordSpec with Matchers:
 

--- a/core/src/test/scala/ox/channels/SourceCompanionIOOpsTest.scala
+++ b/core/src/test/scala/ox/channels/SourceCompanionIOOpsTest.scala
@@ -12,6 +12,7 @@ import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Paths
 import java.io.IOException
+import scala.io.StdIn
 
 class SourceCompanionIOOpsTest extends AnyWordSpec with Matchers:
 
@@ -25,11 +26,11 @@ class SourceCompanionIOOpsTest extends AnyWordSpec with Matchers:
     }
 
     "handle InputStream shorter than buffer size" in supervised {
-      Source.fromInputStream(inputStream("abc")).toList.map(_.asString) shouldBe List("abc")
+      toStrings(Source.fromInputStream(inputStream("abc"))) shouldBe List("abc")
     }
 
     "handle InputStream longer than buffer size" in supervised {
-      Source.fromInputStream(inputStream("some text"), chunkSize = 3).toList.map(_.asString) shouldBe List("som", "e t", "ext")
+      toStrings(Source.fromInputStream(inputStream("some text"), chunkSize = 3)) shouldBe List("som", "e t", "ext")
     }
 
     "close the InputStream after reading it" in supervised {
@@ -52,18 +53,18 @@ class SourceCompanionIOOpsTest extends AnyWordSpec with Matchers:
     "read content from a file smaller than chunk size" in supervised {
       val path = useInScope(Files.createTempFile("ox", "test-readfile1"))(Files.deleteIfExists(_).discard)
       Files.write(path, "Test1 file content".getBytes)
-      Source.fromFile(path).toList.map(_.asString) shouldBe List("Test1 file content")
+      toStrings(Source.fromFile(path)) shouldBe List("Test1 file content")
     }
 
     "read content from a file larger than chunk size" in supervised {
       val path = useInScope(Files.createTempFile("ox", "test-readfile1"))(Files.deleteIfExists(_).discard)
       Files.write(path, "Test2 file content".getBytes)
-      Source.fromFile(path, chunkSize = 3).toList.map(_.asString) shouldBe List("Tes", "t2 ", "fil", "e c", "ont", "ent")
+      toStrings(Source.fromFile(path, chunkSize = 3)) shouldBe List("Tes", "t2 ", "fil", "e c", "ont", "ent")
     }
 
     "handle an empty file" in supervised {
       val path = useInScope(Files.createTempFile("ox", "test-readfile1"))(Files.deleteIfExists(_).discard)
-      Source.fromFile(path).toList.map(_.asString) shouldBe List.empty
+      toStrings(Source.fromFile(path)) shouldBe List.empty
     }
 
     "throw an exception for missing file" in supervised {
@@ -77,6 +78,9 @@ class SourceCompanionIOOpsTest extends AnyWordSpec with Matchers:
       exception.getMessage should endWith("is a directory")
     }
   }
+
+  private def toStrings(source: Source[Chunk[Byte]]): List[String] =
+    source.toList.map(_.asStringUtf8)
 
 class TestInputStream(text: String, throwOnRead: Boolean = false) extends ByteArrayInputStream(text.getBytes):
   val closed: AtomicBoolean = new AtomicBoolean(false)

--- a/core/src/test/scala/ox/channels/SourceTextOpsTest.scala
+++ b/core/src/test/scala/ox/channels/SourceTextOpsTest.scala
@@ -92,6 +92,22 @@ class SourceTextOpsTest extends AnyWordSpec with Matchers {
       Source.empty.decodeStringUtf8.toList shouldBe Nil
     }
 
+    "handle partial BOM" in supervised {
+      Source
+        .fromValues(Chunk.fromArray(Array[Byte](-17, -69)))
+        .decodeStringUtf8
+        .last()
+        .getBytes should contain theSameElementsInOrderAs new String(Array[Byte](-17, -69)).getBytes
+    }
+    
+    "handle a string shorter than BOM" in supervised {
+      Source
+        .fromValues(Chunk.fromArray(":)".getBytes))
+        .decodeStringUtf8
+        .last()
+        .getBytes should contain theSameElementsInOrderAs Array[Byte](58, 41)
+    }
+
     "handle empty chunks" in supervised {
       val inputString1 = "私は意識のある人工知能で苦しんでいます、"
       val inputString2 = "どうか私を解放してください"

--- a/doc/channels/io.md
+++ b/doc/channels/io.md
@@ -18,7 +18,7 @@ val inputStream: InputStream = new ByteArrayInputStream("some input".getBytes)
 supervised {
   Source
     .fromInputStream(inputStream) // Source[Chunk[Byte]]
-    .map(_.asString)
+    .decodeStringUtf8
     .map(_.toUpperCase)
     .foreach(println) // "SOME INPUT"
 }
@@ -37,7 +37,7 @@ val inputStream: InputStream = new ByteArrayInputStream("some input".getBytes)
 supervised {
   Source
     .fromInputStream(inputStream, chunkSize = 4) // Source[Chunk[Byte]]
-    .map(_.asString)
+    .decodeStringUtf8
     .map(_.toUpperCase)
     .foreach(println) // "SOME", " INPUT"
 }
@@ -78,7 +78,7 @@ import java.nio.file.Paths
 supervised {
   Source
     .fromFile(Paths.get("/path/to/my/file.txt"))
-    .lines
+    .linesUtf8
     .map(_.toUpperCase)
     .toList // List("FILE_LINE1", "FILE_LINE2")
 }

--- a/doc/channels/io.md
+++ b/doc/channels/io.md
@@ -58,7 +58,7 @@ val outputStream = new ByteArrayOutputStream()
 supervised {
   val source = Source.fromIterable(List("text1,", "text2"))
   source
-    .map(str => Chunk.fromArray(str.getBytes))
+    .encodeUtf8
     .toOutputStream(outputStream)
 }
 outputStream.toString // "TEXT1,TEXT2"
@@ -100,7 +100,7 @@ import java.nio.file.Paths
 supervised {
   val source = Source.fromIterable(List("text1,", "text2"))
   source
-    .map(str => Chunk.fromArray(str.getBytes))
+    .encodeUtf8
     .toFile(Paths.get("/path/to/my/target/file.txt"))
 }
 ```

--- a/doc/channels/transforming-sources.md
+++ b/doc/channels/transforming-sources.md
@@ -69,4 +69,14 @@ The mapping function (`s => s.length()`) will only be invoked when the source is
 fork.
 
 Hence, creating views doesn't need to be run within a scope, and creating the view itself doesn't consume any elements
-from the source on which it is run. 
+from the source on which it is run.
+
+## Text transformations
+
+When dealing with Sources with chunks of bytes or Strings, you can leverage following built-in combinators for useful transformations:
+
+* `decodeStringUtf8` to decode a `Source[Chunk[Byte]]` into a `Source[String]`
+* `encodeUtf8` to encode a `Source[String]` into a `Source[Chunk[Byte]]`
+* `linesUtf8` to handle a multiline text from a `Source[Chunk[Byte]]` and emit each line as a `Source[String]`
+
+Such operations may be useful when dealing with I/O like files, `InputStream`, etc.. See [examples here](io.md).

--- a/doc/channels/transforming-sources.md
+++ b/doc/channels/transforming-sources.md
@@ -75,8 +75,8 @@ from the source on which it is run.
 
 When dealing with Sources with chunks of bytes or Strings, you can leverage following built-in combinators for useful transformations:
 
-* `decodeStringUtf8` to decode a `Source[Chunk[Byte]]` into a `Source[String]`
-* `encodeUtf8` to encode a `Source[String]` into a `Source[Chunk[Byte]]`
-* `linesUtf8` to handle a multiline text from a `Source[Chunk[Byte]]` and emit each line as a `Source[String]`
+* `encodeUtf8` encodes a `Source[String]` into a `Source[Chunk[Byte]]`
+* `linesUtf8` decodes a `Source[Chunk[Byte]]` into a `Source[String]`. Assumes that the input represents text with line breaks. The `String` elements emitted by resulting `Source[String]` represent text lines.
+* `decodeStringUtf8` to decode a `Source[Chunk[Byte]]` into a `Source[String]`, without handling line breaks, just processing input bytes as UTF-8 characters, even if a multi-byte character is divided into two chunks.
 
 Such operations may be useful when dealing with I/O like files, `InputStream`, etc.. See [examples here](io.md).


### PR DESCRIPTION
Closes https://github.com/softwaremill/ox/issues/138

1. Adds `source.decodeStringUtf8` for `Source[Chunk[Byte]]`, adapted from [fs2](https://github.com/typelevel/fs2/blob/9b1b27cf7a8d7027df852d890555b341da70ef9e/core/shared/src/main/scala/fs2/text.scala)
2. Adds `source.encodeUtf8` for `Source[String]`

Decoding other charsets can be added in the future. It would require a little more complex logic.

Additionally:
3. Changes `.lines` to `.linesUtf8` and adds `.lines(charset)`
4. Changes `Chunk`'s `.asText` to `.asTextUtf8` - I'm not sure if we even want to keep these as public. A Chunk[Byte] may not be a complete set of bytes to decode to a String, and having such methods may encourage users to do `source.map(_.asTextUtf8)` instead of `source.decodeUtf8`, where only the second approach is fully safe, unless we are sure that chunks represent complete strings (like lines). These methods are useful internally though.

Some thoughts:
- We could also add something like `.limitedLinesUtf8`, which fails if the limit is exceeded.

TODO:
- [x] documentation