### PR TITLE
Proposal: prevent either block nesting to avoid type/try-catch mismatches

### DIFF
--- a/core/src/main/scala/ox/either.scala
+++ b/core/src/main/scala/ox/either.scala
@@ -1,11 +1,15 @@
 package ox
 
+import scala.annotation.implicitNotFound
 import scala.compiletime.{error, summonFrom}
-import scala.util.boundary
+import scala.util.{NotGiven, boundary}
 import scala.util.boundary.{Label, break}
 import scala.util.control.NonFatal
 
 object either:
+
+  private type NotNested = NotGiven[Label[Either[Nothing, Nothing]]]
+
   /** Within an [[either]] block, allows unwrapping [[Either]] and [[Option]] values using [[ok()]]. The result is the right-value of an
     * `Either`, or the defined-value of the `Option`. In case a failure is encountered (a left-value of an `Either`, or a `None`), the
     * computation is short-circuited and the failure becomes the result. Failures can also be reported using [[fail()]].
@@ -32,7 +36,11 @@ object either:
     *       v1.ok() ++ v2.ok()
     *   }}}
     */
-  inline def apply[E, A](inline body: Label[Either[E, A]] ?=> A): Either[E, A] = boundary(Right(body))
+  inline def apply[E, A](inline body: Label[Either[E, A]] ?=> A)(using
+      @implicitNotFound(
+        "Nesting of either blocks is not allowed as it's bug prone with type inference. Consider extracting the nested either block to a separate function."
+      ) nn: NotNested
+  ): Either[E, A] = boundary(Right(body))
 
   extension [E, A](inline t: Either[E, A])
     /** Unwrap the value of the `Either`, short-circuiting the computation to the enclosing [[either]], in case this is a left-value. */


### PR DESCRIPTION
Either blocks, based on boundaries, provide implicit evidence for safe jumps. One problematic case is when `.ok()` combinator is called on a fork (or inside of exception capturing scope that can swallow a Break), another is when nested boundaries provide evidences for mismatched cases:

```scala
val effectMatchingOuterEither: Either[Throwable, Unit] = Left(Exception("oh no"))
val effectMatchingInnerEither: Either[String, Int] = Right(3)

val outer: Either[Throwable, Unit] = either {
  val inner: Either[String, Int] = either {
    effectMatchingOuterEither.ok()
    effectMatchingInnerEither.ok()
  }

  ()
}
 ```
 
Notice that first `Either` value evaluated with `.ok()` matches outer `either` block while being evaluated in the inner block. This might very well be considered a feature - types allow us to decide where to jump - but in my short but stressful experience with this kind of combinators - when this is used with type inference, results can be surprising. In my case the inner block was the body of Tapir handler while outer either block was in main function. The result was, unsurprisingly, a thread killed with `Break`. I would get a compilation error if nested either blocks were not allowed because without the outer block I'd be informed that it's impossible to use `.ok()` as `either` block in tapir handler is inferred to be `Either[Unit, String]`. I know this is a rather heavy-handed change and there are possible use cases for nested either blocks (tagged jumps for example) but this is confusing enough imho to warrant such a change. I can easily imagine such a change to occur during refactoring of code where inner either block stops matching one of the eithers with `.ok()` in it's scope and outer either providing evidence where it's no longer handled correctly. 