### PR TITLE
move catching to either object and make it an either block operator

### DIFF
--- a/core/src/main/scala/ox/either.scala
+++ b/core/src/main/scala/ox/either.scala
@@ -47,23 +47,6 @@ object either:
       ) nn: NotNested
   ): Either[E, A] = boundary(Right(body))
 
-  extension [E, A](inline t: Right[E, A])
-    /** Unwrap the value of the `Either`, returning value of type `A` on guaranteed `Right` case. */
-    transparent inline def ok(): A =
-      t match
-        case Right(a) => a
-
-  extension [E, A](inline t: Left[E, A])
-    /** Unwrap the value of the `Either`, short-circuiting the computation to the enclosing [[either]]. */
-    transparent inline def ok(): A =
-      summonFrom {
-        case given boundary.Label[Either[E, Nothing]] =>
-          break(t.asInstanceOf[Either[E, Nothing]])
-        case given boundary.Label[Either[Nothing, Nothing]] =>
-          error("The enclosing `either` call uses a different error type.\nIf it's explicitly typed, is the error type correct?")
-        case _ => error("`.ok()` can only be used within an `either` call.\nIs it present?")
-      }
-
   extension [E, A](inline t: Either[E, A])
     /** Unwrap the value of the `Either`, short-circuiting the computation to the enclosing [[either]], in case this is a left-value. */
     transparent inline def ok(): A =
@@ -77,6 +60,24 @@ object either:
         case _ => error("`.ok()` can only be used within an `either` call.\nIs it present?")
       }
 
+  /** Specialized extensions for Right & Left are necessary to prevent compile-time warning about unreachable cases in inlined pattern
+    * matches when call site has a specific type.
+    */
+  extension [E, A](inline t: Right[E, A])
+    /** Unwrap the value of the `Either`, returning value of type `A` on guaranteed `Right` case. */
+    transparent inline def ok(): A = t.value
+
+  extension [E, A](inline t: Left[E, A])
+    /** Unwrap the value of the `Either`, short-circuiting the computation to the enclosing [[either]]. */
+    transparent inline def ok(): A =
+      summonFrom {
+        case given boundary.Label[Either[E, Nothing]] =>
+          break(t.asInstanceOf[Either[E, Nothing]])
+        case given boundary.Label[Either[Nothing, Nothing]] =>
+          error("The enclosing `either` call uses a different error type.\nIf it's explicitly typed, is the error type correct?")
+        case _ => error("`.ok()` can only be used within an `either` call.\nIs it present?")
+      }
+
   extension [A](inline t: Option[A])
     /** Unwrap the value of the `Option`, short-circuiting the computation to the enclosing [[either]], in case this is a `None`. */
     transparent inline def ok(): A =
@@ -85,6 +86,25 @@ object either:
           t match
             case None    => break(Left(()))
             case Some(a) => a
+        case given boundary.Label[Either[Nothing, Nothing]] =>
+          error(
+            "The enclosing `either` call uses a different error type.\nIf it's explicitly typed, is the error type correct?\nNote that for options, the error type must contain a `Unit`."
+          )
+        case _ => error("`.ok()` can only be used within an `either` call.\nIs it present?")
+      }
+
+  /** Specialized extensions for Some & None are necessary to prevent compile-time warning about unreachable cases in inlined pattern
+    * matches when call site has a specific type.
+    */
+  extension [A](inline t: Some[A])
+    /** Unwrap the value of the `Option`, returning value of type `A` on guaranteed `Some` case. */
+    transparent inline def ok(): A = t.value
+
+  extension [A](inline t: None.type)
+    /** Unwrap the value of the `Option`, short-circuiting the computation to the enclosing [[either]] on guaranteed `None`. */
+    transparent inline def ok(): A =
+      summonFrom {
+        case given boundary.Label[Either[Unit, Nothing]] => break(Left(()))
         case given boundary.Label[Either[Nothing, Nothing]] =>
           error(
             "The enclosing `either` call uses a different error type.\nIf it's explicitly typed, is the error type correct?\nNote that for options, the error type must contain a `Unit`."

--- a/doc/basics/error-handling.md
+++ b/doc/basics/error-handling.md
@@ -131,9 +131,9 @@ Exception-throwing code can be converted to an `Either` using `catching`. Note t
 exceptions!
 
 ```scala mdoc:compile-only
-import ox.catching
+import ox.either
 
-val result: Either[Throwable, String] = catching(throw new RuntimeException("boom"))
+val result: Either[Throwable, String] = either.catching(throw new RuntimeException("boom"))
 ```
 
 ### Nested `either` blocks

--- a/doc/basics/quick-example.md
+++ b/doc/basics/quick-example.md
@@ -18,7 +18,7 @@ val result1: (Int, String) = par(computation1, computation2)
 
 // timeout a computation
 def computation: Int = { sleep(2.seconds); 1 }
-val result2: Either[Throwable, Int] = catching(timeout(1.second)(computation))
+val result2: Either[Throwable, Int] = either.catching(timeout(1.second)(computation))
 
 // structured concurrency & supervision
 supervised {

--- a/generated-doc/out/basics/error-handling.md
+++ b/generated-doc/out/basics/error-handling.md
@@ -131,9 +131,9 @@ Exception-throwing code can be converted to an `Either` using `catching`. Note t
 exceptions!
 
 ```scala
-import ox.catching
+import ox.either
 
-val result: Either[Throwable, String] = catching(throw new RuntimeException("boom"))
+val result: Either[Throwable, String] = either.catching(throw new RuntimeException("boom"))
 ```
 
 ### Nested `either` blocks

--- a/generated-doc/out/basics/quick-example.md
+++ b/generated-doc/out/basics/quick-example.md
@@ -18,7 +18,7 @@ val result1: (Int, String) = par(computation1, computation2)
 
 // timeout a computation
 def computation: Int = { sleep(2.seconds); 1 }
-val result2: Either[Throwable, Int] = catching(timeout(1.second)(computation))
+val result2: Either[Throwable, Int] = either.catching(timeout(1.second)(computation))
 
 // structured concurrency & supervision
 supervised {


### PR DESCRIPTION
also fixes unreachable case warning by adding specialised `ok()` operators:
```
[warn] -- [E030] Match case Unreachable Warning: /Users/lbialy/Projects/foss/ox/core/src/test/scala/ox/EitherTest.scala:145:65
[warn] 145 |    val r1 = either((1 to 20).toVector.mapPar(3)(i => Right(i).ok()))
[warn]     |                                                      ^^^^^^^^^^^^^
[warn]     |                                                      Unreachable case
[warn]     |---------------------------------------------------------------------------
[warn]     |Inline stack trace
[warn]     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[warn]     |This location contains code that was inlined from either.scala:56
[warn]  56 |            case Left(e)  => break(Left(e))
[warn]     |                 ^^^^^^^
[warn]      ---------------------------------------------------------------------------
[warn] one warning found
```