### PR TITLE
Catch only non-fatal exceptions in Source.lines

### DIFF
--- a/core/src/main/scala/ox/channels/SourceCompanionIOOps.scala
+++ b/core/src/main/scala/ox/channels/SourceCompanionIOOps.scala
@@ -84,7 +84,7 @@ trait SourceCompanionIOOps:
             if readBytes > 0 then chunks.send(Chunk.fromArray(if readBytes == chunkSize then buf.array else buf.array.take(readBytes)))
             true
         }
-      } catch case e => chunks.errorOrClosed(e).discard
+      } catch case NonFatal(e) => chunks.errorOrClosed(e).discard
       finally
         try jFileChannel.close()
         catch


### PR DESCRIPTION
Otherwise Control-C doesn't terminate the program.