### PR TITLE
Handle ControlThrowable exception in 'race' function

### DIFF
--- a/core/src/test/scala/ox/util/NastyControlThrowable.scala
+++ b/core/src/test/scala/ox/util/NastyControlThrowable.scala
@@ -1,5 +1,0 @@
-package ox.util
-
-import scala.util.control.ControlThrowable
-
-class NastyControlThrowable(val message: String) extends ControlThrowable(message) {}

--- a/core/src/test/scala/ox/util/NastyControlThrowable.scala
+++ b/core/src/test/scala/ox/util/NastyControlThrowable.scala
@@ -1,0 +1,5 @@
+package ox.util
+
+import scala.util.control.ControlThrowable
+
+class NastyControlThrowable(val message: String) extends ControlThrowable(message) {}


### PR DESCRIPTION
I added the handling of a `ControThrowable` to the internals of the `race` function. The `ControThrowable` exceptions have suppression disabled by default, so it's not possible to accumulate suppressed exceptions.

Feel free to let me know if anything needs clarification or if you notice something needs to be improved.

Closes #213 