### PR TITLE
Set oxThreadFactory globally, instead of a fork local

### DIFF
--- a/core/src/main/scala/ox/Ox.scala
+++ b/core/src/main/scala/ox/Ox.scala
@@ -4,7 +4,6 @@ import ox.channels.Actor
 import ox.channels.ActorRef
 
 import java.util.concurrent.StructuredTaskScope
-import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.implicitNotFound
 
@@ -80,9 +79,4 @@ end OxError
 
 object OxError:
   def apply[E, F[_]](s: Supervisor[E], em: ErrorMode[E, F]): OxError[E, F] =
-    OxError(DoNothingScope[Any](oxThreadFactory.get()), new AtomicReference(Nil), s, em)
-
-/** The thread factory that is used to create threads in Ox scopes ([[supervised]], [[unsupervised]] etc.). Can be customized in a
-  * structured fashion, that is for the duration of evaluating a block of code.
-  */
-val oxThreadFactory: ForkLocal[ThreadFactory] = ForkLocal(Thread.ofVirtual().factory())
+    OxError(DoNothingScope[Any](oxThreadFactory), new AtomicReference(Nil), s, em)

--- a/core/src/main/scala/ox/OxApp.scala
+++ b/core/src/main/scala/ox/OxApp.scala
@@ -32,8 +32,9 @@ trait OxApp:
   protected def settings: OxApp.Settings = OxApp.Settings.Default
 
   final def main(args: Array[String]): Unit =
+    setOxThreadFactory(settings.threadFactory)
     try
-      oxThreadFactory.unsupervisedWhere(settings.threadFactory) {
+      unsupervised {
         val cancellableMainFork = forkCancellable {
           try supervised(run(args.toVector))
           catch
@@ -57,6 +58,8 @@ trait OxApp:
     catch
       // if .joinEither is interrupted, the exception will be rethrown, won't be returned as a Left
       case _: InterruptedException => exit(settings.interruptedExitCode)
+    end try
+  end main
 
   /** For testing - trapping System.exit is impossible due to SecurityManager removal so it's just overrideable in tests. */
   private[ox] def exit(exitCode: ExitCode): Unit = System.exit(exitCode.code)

--- a/core/src/main/scala/ox/oxThreadFactory.scala
+++ b/core/src/main/scala/ox/oxThreadFactory.scala
@@ -1,0 +1,18 @@
+package ox
+
+import java.util.concurrent.ThreadFactory
+
+private var customThreadFactory: ThreadFactory = _
+
+/** @see oxThreadFactory */
+def setOxThreadFactory(tf: ThreadFactory): Unit =
+  customThreadFactory = tf
+  if oxThreadFactory != customThreadFactory then
+    throw new RuntimeException("The thread factory was already used before setting a custom one!")
+
+/** The thread factory that is used to create threads in Ox scopes ([[supervised]], [[unsupervised]] etc.). Should be set once at the start
+  * of the application, before any scopes or forks are created, using [[setOxThreadFactory]].
+  */
+lazy val oxThreadFactory: ThreadFactory =
+  val custom = customThreadFactory
+  if custom == null then Thread.ofVirtual().factory() else custom

--- a/core/src/main/scala/ox/oxThreadFactory.scala
+++ b/core/src/main/scala/ox/oxThreadFactory.scala
@@ -7,7 +7,7 @@ private var customThreadFactory: ThreadFactory = _
 /** @see [[oxThreadFactory]] */
 def setOxThreadFactory(tf: ThreadFactory): Unit =
   customThreadFactory = tf
-  if oxThreadFactory != customThreadFactory then
+  if !oxThreadFactory.eq(customThreadFactory) then
     throw new RuntimeException("The thread factory was already used before setting a custom one!")
 
 /** The thread factory that is used to create threads in Ox scopes ([[supervised]], [[unsupervised]] etc.). Should be set once at the start

--- a/core/src/main/scala/ox/oxThreadFactory.scala
+++ b/core/src/main/scala/ox/oxThreadFactory.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.ThreadFactory
 
 private var customThreadFactory: ThreadFactory = _
 
-/** @see oxThreadFactory */
+/** @see [[oxThreadFactory]] */
 def setOxThreadFactory(tf: ThreadFactory): Unit =
   customThreadFactory = tf
   if oxThreadFactory != customThreadFactory then
@@ -12,6 +12,9 @@ def setOxThreadFactory(tf: ThreadFactory): Unit =
 
 /** The thread factory that is used to create threads in Ox scopes ([[supervised]], [[unsupervised]] etc.). Should be set once at the start
   * of the application, before any scopes or forks are created, using [[setOxThreadFactory]].
+  *
+  * @see
+  *   [[OxApp]]
   */
 lazy val oxThreadFactory: ThreadFactory =
   val custom = customThreadFactory

--- a/core/src/main/scala/ox/oxThreadFactory.scala
+++ b/core/src/main/scala/ox/oxThreadFactory.scala
@@ -14,7 +14,7 @@ def setOxThreadFactory(tf: ThreadFactory): Unit =
   * of the application, before any scopes or forks are created, using [[setOxThreadFactory]].
   *
   * @see
-  *   [[OxApp]]
+  *   [[OxApp.Settings]]
   */
 lazy val oxThreadFactory: ThreadFactory =
   val custom = customThreadFactory

--- a/doc/integrations/otel-context.md
+++ b/doc/integrations/otel-context.md
@@ -12,9 +12,8 @@ will not be propagated across virtual thread boundaries, e.g. when creating new 
 into traces, or metrics without the appropriate context.
 
 To fix this problem, the context must be propagated whenever a new virtual thread is created. One way to achieve this
-is by using a custom thread factory, provided by this module - `PropagatingVirtualThreadFactory`. It can be set within
-a scope by using the `oxThreadFactory` [fork local](../structured-concurrency/fork-local.md), or for the whole app
-when using [`OxApp`](../utils/oxapp.md):
+is by using a custom thread factory, provided by this module - `PropagatingVirtualThreadFactory`. It can be set 
+globally using `oxThreadFactory`, or for the whole app when using [`OxApp`](../utils/oxapp.md):
 
 ```scala mdoc:compile-only
 import ox.*

--- a/doc/integrations/otel-context.md
+++ b/doc/integrations/otel-context.md
@@ -21,7 +21,7 @@ import ox.otel.context.PropagatingVirtualThreadFactory
 
 object MyApp extends OxApp:
   override def settings: OxApp.Settings = OxApp.Settings.Default.copy(
-    threadFactory = PropagatingVirtualThreadFactory()
+    threadFactory = Some(PropagatingVirtualThreadFactory())
   )
   
   def run(args: Vector[String])(using Ox): ExitCode = ExitCode.Success

--- a/doc/integrations/otel-context.md
+++ b/doc/integrations/otel-context.md
@@ -13,7 +13,7 @@ into traces, or metrics without the appropriate context.
 
 To fix this problem, the context must be propagated whenever a new virtual thread is created. One way to achieve this
 is by using a custom thread factory, provided by this module - `PropagatingVirtualThreadFactory`. It can be set 
-globally using `oxThreadFactory`, or for the whole app when using [`OxApp`](../utils/oxapp.md):
+for the whole app when using [`OxApp`](../utils/oxapp.md), or manually through `oxThreadFactory`:
 
 ```scala mdoc:compile-only
 import ox.*

--- a/doc/structured-concurrency/fork-join.md
+++ b/doc/structured-concurrency/fork-join.md
@@ -136,4 +136,4 @@ completed.
 ## Customizing thread creation
 
 By default, for each fork a new virtual thread is created using `Thread.ofVirtual().factory()`. This can be customized
-using the `oxThreadFactory` [fork local](fork-local.md).
+globally using `oxThreadFactory`.

--- a/otel-context/src/main/scala/ox/otel/context/PropagatingVirtualThreadFactory.scala
+++ b/otel-context/src/main/scala/ox/otel/context/PropagatingVirtualThreadFactory.scala
@@ -5,7 +5,7 @@ import io.opentelemetry.context.Context
 
 /** A virtual thread factory which propagates the OpenTelemetry [[Context]] when creating new threads.
   *
-  * Should be used in [[ox.OxApp]] settings (as `threadFactory`), or using the [[ox.oxThreadFactory]] fork local.
+  * Should be used in [[ox.OxApp]] settings (as `threadFactory`), or using the [[ox.oxThreadFactory]].
   */
 class PropagatingVirtualThreadFactory extends ThreadFactory:
   private val delegate = Thread.ofVirtual().factory()


### PR DESCRIPTION
When using a fork local, the thread factory was not used in other platform threads, created outside of the virtual thread tree