### PR TITLE
Replace the Schedule used for repeats/retries with an interval-list based approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,15 @@ supervised {
 
 ```scala mdoc:compile-only
 def computationR: Int = ???
-retry(RetryConfig.backoff(3, 100.millis, 5.minutes, Jitter.Equal))(computationR)
+retry(Schedule.exponentialBackoff(100.millis).maxRepeats(5)
+  .jitter().maxInterval(5.minutes))(computationR)
 ```
 
 [Repeat](https://ox.softwaremill.com/latest/utils/repeat.html) a computation:
 
 ```scala mdoc:compile-only
 def computationR: Int = ???
-repeat(RepeatConfig.fixedRateForever(100.millis))(computationR)
+repeat(Schedule.fixedInterval(100.millis))(computationR)
 ```
 
 [Rate limit](https://ox.softwaremill.com/latest/utils/rate-limiter.html) computations:

--- a/core/src/main/scala/ox/resilience/AdaptiveRetry.scala
+++ b/core/src/main/scala/ox/resilience/AdaptiveRetry.scala
@@ -1,7 +1,11 @@
 package ox.resilience
 
-import ox.scheduling.{ScheduleStop, ScheduledConfig, SleepMode, scheduledWithErrorMode}
 import ox.*
+import ox.scheduling.Schedule
+import ox.scheduling.ScheduleStop
+import ox.scheduling.ScheduledConfig
+import ox.scheduling.SleepMode
+import ox.scheduling.scheduledWithErrorMode
 
 import scala.util.Try
 
@@ -40,7 +44,8 @@ case class AdaptiveRetry(
     * the operation aren't caught (unless the operation catches them as part of its implementation) and don't cause a retry to happen.
     *
     * @param config
-    *   The retry config - See [[RetryConfig]].
+    *   The retry config. Includes a [[Schedule]] which determines the intervals between invocations and number of attempts to execute the
+    *   operation.
     * @param shouldPayFailureCost
     *   Function to decide if returned result Either[E, T] should be considered failure in terms of paying cost for retry. Penalty is paid
     *   only if it is decided to retry operation, the penalty will not be paid for successful operation. Defaults to `true`.
@@ -58,12 +63,10 @@ case class AdaptiveRetry(
     *   Either:
     *   - the result of the function if it eventually succeeds, in the context of `F`, as dictated by the error mode.
     *   - the error `E` in context `F` as returned by the last attempt if the config decides to stop.
-    * @see
-    *   [[scheduledWithErrorMode]]
     */
   def retryWithErrorMode[E, T, F[_]](errorMode: ErrorMode[E, F])(
       config: RetryConfig[E, T],
-      shouldPayFailureCost: Either[E, T] => Boolean = (_: Either[E, T]) => true
+      shouldPayFailureCost: Either[E, T] => Boolean
   )(operation: => F[T]): F[T] =
 
     val afterAttempt: (Int, Either[E, T]) => ScheduleStop = (attemptNum, attempt) =>
@@ -95,11 +98,94 @@ case class AdaptiveRetry(
     scheduledWithErrorMode(errorMode)(scheduledConfig)(operation)
   end retryWithErrorMode
 
+  /** Retries an operation using the given error mode until it succeeds or the config decides to stop. Note that any exceptions thrown by
+    * the operation aren't caught (unless the operation catches them as part of its implementation) and don't cause a retry to happen.
+    *
+    * @param config
+    *   The retry config. Includes a [[Schedule]] which determines the intervals between invocations and number of attempts to execute the
+    *   operation.
+    * @param errorMode
+    *   The error mode to use, which specifies when a result value is considered success, and when a failure.
+    * @param operation
+    *   The operation to retry.
+    * @tparam E
+    *   type of error.
+    * @tparam T
+    *   type of result of an operation.
+    * @tparam F
+    *   the context inside which [[E]] or [[T]] are returned.
+    * @return
+    *   Either:
+    *   - the result of the function if it eventually succeeds, in the context of `F`, as dictated by the error mode.
+    *   - the error `E` in context `F` as returned by the last attempt if the config decides to stop.
+    */
+  def retryWithErrorMode[E, T, F[_]](errorMode: ErrorMode[E, F])(
+      config: RetryConfig[E, T]
+  )(operation: => F[T]): F[T] =
+    retryWithErrorMode(errorMode)(config, (_: Either[E, T]) => true)(operation)
+
+  /** Retries an operation using the given error mode until it succeeds or the config decides to stop. Note that any exceptions thrown by
+    * the operation aren't caught (unless the operation catches them as part of its implementation) and don't cause a retry to happen. Uses
+    * the default [[RetryConfig]], with the given [[Schedule]].
+    *
+    * @param schedule
+    *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+    * @param shouldPayFailureCost
+    *   Function to decide if returned result Either[E, T] should be considered failure in terms of paying cost for retry. Penalty is paid
+    *   only if it is decided to retry operation, the penalty will not be paid for successful operation. Defaults to `true`.
+    * @param errorMode
+    *   The error mode to use, which specifies when a result value is considered success, and when a failure.
+    * @param operation
+    *   The operation to retry.
+    * @tparam E
+    *   type of error.
+    * @tparam T
+    *   type of result of an operation.
+    * @tparam F
+    *   the context inside which [[E]] or [[T]] are returned.
+    * @return
+    *   Either:
+    *   - the result of the function if it eventually succeeds, in the context of `F`, as dictated by the error mode.
+    *   - the error `E` in context `F` as returned by the last attempt if the config decides to stop.
+    */
+  def retryWithErrorMode[E, T, F[_]](errorMode: ErrorMode[E, F])(
+      schedule: Schedule,
+      shouldPayFailureCost: Either[E, T] => Boolean
+  )(operation: => F[T]): F[T] =
+    retryWithErrorMode(errorMode)(RetryConfig(schedule), shouldPayFailureCost)(operation)
+
+  /** Retries an operation using the given error mode until it succeeds or the config decides to stop. Note that any exceptions thrown by
+    * the operation aren't caught (unless the operation catches them as part of its implementation) and don't cause a retry to happen. Uses
+    * the default [[RetryConfig]], with the given [[Schedule]].
+    *
+    * @param schedule
+    *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+    * @param errorMode
+    *   The error mode to use, which specifies when a result value is considered success, and when a failure.
+    * @param operation
+    *   The operation to retry.
+    * @tparam E
+    *   type of error.
+    * @tparam T
+    *   type of result of an operation.
+    * @tparam F
+    *   the context inside which [[E]] or [[T]] are returned.
+    * @return
+    *   Either:
+    *   - the result of the function if it eventually succeeds, in the context of `F`, as dictated by the error mode.
+    *   - the error `E` in context `F` as returned by the last attempt if the config decides to stop.
+    */
+  def retryWithErrorMode[E, T, F[_]](errorMode: ErrorMode[E, F])(
+      schedule: Schedule
+  )(operation: => F[T]): F[T] =
+    retryWithErrorMode(errorMode)(RetryConfig(schedule))(operation)
+
   /** Retries an operation returning an [[scala.util.Either]] until it succeeds or the config decides to stop. Note that any exceptions
     * thrown by the operation aren't caught and don't cause a retry to happen.
     *
     * @param config
-    *   The retry config - see [[RetryConfig]].
+    *   The retry config. Includes a [[Schedule]] which determines the intervals between invocations and number of attempts to execute the
+    *   operation.
     * @param shouldPayFailureCost
     *   Function to decide if returned result Either[E, T] should be considered failure in terms of paying cost for retry. Penalty is paid
     *   only if it is decided to retry operation, the penalty will not be paid for successful operation. Defaults to `true`.
@@ -112,35 +198,142 @@ case class AdaptiveRetry(
     * @return
     *   A [[scala.util.Right]] if the function eventually succeeds, or, otherwise, a [[scala.util.Left]] with the error from the last
     *   attempt.
-    * @see
-    *   [[scheduledEither]]
     */
-  def retryEither[E, T](config: RetryConfig[E, T], shouldPayFailureCost: Either[E, T] => Boolean = (_: Either[E, T]) => true)(
+  def retryEither[E, T](config: RetryConfig[E, T], shouldPayFailureCost: Either[E, T] => Boolean)(
       operation: => Either[E, T]
   ): Either[E, T] =
     retryWithErrorMode(EitherMode[E])(config, shouldPayFailureCost)(operation)
 
+  /** Retries an operation returning an [[scala.util.Either]] until it succeeds or the config decides to stop. Note that any exceptions
+    * thrown by the operation aren't caught and don't cause a retry to happen.
+    *
+    * @param config
+    *   The retry config. Includes a [[Schedule]] which determines the intervals between invocations and number of attempts to execute the
+    *   operation.
+    * @param operation
+    *   The operation to retry.
+    * @tparam E
+    *   type of error.
+    * @tparam T
+    *   type of result of an operation.
+    * @return
+    *   A [[scala.util.Right]] if the function eventually succeeds, or, otherwise, a [[scala.util.Left]] with the error from the last
+    *   attempt.
+    */
+  def retryEither[E, T](config: RetryConfig[E, T])(operation: => Either[E, T]): Either[E, T] =
+    retryEither(config, (_: Either[E, T]) => true)(operation)
+
+  /** Retries an operation returning an [[scala.util.Either]] until it succeeds or the config decides to stop. Note that any exceptions
+    * thrown by the operation aren't caught and don't cause a retry to happen. Uses the default [[RetryConfig]], with the given
+    * [[Schedule]].
+    *
+    * @param schedule
+    *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+    * @param shouldPayFailureCost
+    *   Function to decide if returned result Either[E, T] should be considered failure in terms of paying cost for retry. Penalty is paid
+    *   only if it is decided to retry operation, the penalty will not be paid for successful operation. Defaults to `true`.
+    * @param operation
+    *   The operation to retry.
+    * @tparam E
+    *   type of error.
+    * @tparam T
+    *   type of result of an operation.
+    * @return
+    *   A [[scala.util.Right]] if the function eventually succeeds, or, otherwise, a [[scala.util.Left]] with the error from the last
+    *   attempt.
+    */
+  def retryEither[E, T](schedule: Schedule, shouldPayFailureCost: Either[E, T] => Boolean)(
+      operation: => Either[E, T]
+  ): Either[E, T] =
+    retryEither(RetryConfig(schedule), shouldPayFailureCost)(operation)
+
+  /** Retries an operation returning an [[scala.util.Either]] until it succeeds or the config decides to stop. Note that any exceptions
+    * thrown by the operation aren't caught and don't cause a retry to happen. Uses the default [[RetryConfig]], with the given
+    * [[Schedule]].
+    *
+    * @param schedule
+    *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+    * @param operation
+    *   The operation to retry.
+    * @tparam E
+    *   type of error.
+    * @tparam T
+    *   type of result of an operation.
+    * @return
+    *   A [[scala.util.Right]] if the function eventually succeeds, or, otherwise, a [[scala.util.Left]] with the error from the last
+    *   attempt.
+    */
+  def retryEither[E, T](schedule: Schedule)(operation: => Either[E, T]): Either[E, T] =
+    retryEither(RetryConfig(schedule))(operation)
+
   /** Retries an operation returning a direct result until it succeeds or the config decides to stop.
     *
     * @param config
-    *   The retry config - see [[RetryConfig]].
+    *   The retry config. Includes a [[Schedule]] which determines the intervals between invocations and number of attempts to execute the
+    *   operation.
     * @param shouldPayFailureCost
     *   Function to decide if returned result Either[E, T] should be considered failure in terms of paying cost for retry. Penalty is paid
     *   only if it is decided to retry operation, the penalty will not be paid for successful operation. Defaults to `true`.
     * @param operation
     *   The operation to retry.
     * @return
-    *   The result of the function if it eventually succeeds.
+    *   The result of the function when it eventually succeeds.
     * @throws anything
-    *   The exception thrown by the last attempt if the config decides to stop.
-    * @see
-    *   [[scheduled]]
+    *   The exception thrown by the last attempt if the config decides to stop retrying.
     */
   def retry[T](
       config: RetryConfig[Throwable, T],
-      shouldPayFailureCost: Either[Throwable, T] => Boolean = (_: Either[Throwable, T]) => true
+      shouldPayFailureCost: Either[Throwable, T] => Boolean
   )(operation: => T): T =
     retryWithErrorMode(EitherMode[Throwable])(config, shouldPayFailureCost)(Try(operation).toEither).fold(throw _, identity)
+
+  /** Retries an operation returning a direct result until it succeeds or the config decides to stop.
+    *
+    * @param config
+    *   The retry config. Includes a [[Schedule]] which determines the intervals between invocations and number of attempts to execute the
+    *   operation.
+    * @param operation
+    *   The operation to retry.
+    * @return
+    *   The result of the function when it eventually succeeds.
+    * @throws anything
+    *   The exception thrown by the last attempt if the config decides to stop retrying.
+    */
+  def retry[T](config: RetryConfig[Throwable, T])(operation: => T): T = retry(config, (_: Either[Throwable, T]) => true)(operation)
+
+  /** Retries an operation returning a direct result until it succeeds or the config decides to stop. Uses the default [[RetryConfig]], with
+    * the given [[Schedule]].
+    *
+    * @param schedule
+    *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+    * @param shouldPayFailureCost
+    *   Function to decide if returned result Either[E, T] should be considered failure in terms of paying cost for retry. Penalty is paid
+    *   only if it is decided to retry operation, the penalty will not be paid for successful operation. Defaults to `true`.
+    * @param operation
+    *   The operation to retry.
+    * @return
+    *   The result of the function when it eventually succeeds.
+    * @throws anything
+    *   The exception thrown by the last attempt if the config decides to stop retrying.
+    */
+  def retry[T](
+      schedule: Schedule,
+      shouldPayFailureCost: Either[Throwable, T] => Boolean
+  )(operation: => T): T = retry(RetryConfig(schedule), shouldPayFailureCost)(operation)
+
+  /** Retries an operation returning a direct result until it succeeds or the config decides to stop. Uses the default [[RetryConfig]], with
+    * the given [[Schedule]].
+    *
+    * @param schedule
+    *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+    * @param operation
+    *   The operation to retry.
+    * @return
+    *   The result of the function when it eventually succeeds.
+    * @throws anything
+    *   The exception thrown by the last attempt if the config decides to stop retrying.
+    */
+  def retry[T](schedule: Schedule)(operation: => T): T = retry(RetryConfig(schedule))(operation)
 
 end AdaptiveRetry
 

--- a/core/src/main/scala/ox/resilience/AdaptiveRetry.scala
+++ b/core/src/main/scala/ox/resilience/AdaptiveRetry.scala
@@ -92,7 +92,7 @@ case class AdaptiveRetry(
     val scheduledConfig = ScheduledConfig(
       config.schedule,
       afterAttempt,
-      sleepMode = SleepMode.Delay
+      sleepMode = SleepMode.EndToStart
     )
 
     scheduledWithErrorMode(errorMode)(scheduledConfig)(operation)

--- a/core/src/main/scala/ox/resilience/RetryConfig.scala
+++ b/core/src/main/scala/ox/resilience/RetryConfig.scala
@@ -1,23 +1,24 @@
 package ox.resilience
 
-import ox.scheduling.{Jitter, Schedule, ScheduleStop, ScheduledConfig, SleepMode}
+import ox.scheduling.Schedule
+import ox.scheduling.ScheduleStop
+import ox.scheduling.ScheduledConfig
+import ox.scheduling.SleepMode
 
-import scala.concurrent.duration.*
-
-/** A config that defines how to retry a failed operation.
+/** A config that defines how to retry failing operations.
   *
   * It is a special case of [[ScheduledConfig]] with [[ScheduledConfig.sleepMode]] always set to [[SleepMode.Delay]]
   *
   * @param schedule
-  *   The retry schedule which determines the maximum number of retries and the delay between subsequent attempts to execute the operation.
-  *   See [[Schedule]] for more details.
+  *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
   * @param resultPolicy
   *   A policy that allows to customize when a non-erroneous result is considered successful and when an error is worth retrying (which
   *   allows for failing fast on certain errors). See [[ResultPolicy]] for more details.
   * @param onRetry
-  *   A function that is invoked after each retry attempt. The callback receives the number of the current retry attempt (starting from 1)
+  *   A function that is invoked after each retry attempt The callback receives the number of the current retry attempt (starting from 1)
   *   and the result of the operation that was attempted. The result is either a successful value or an error. The callback can be used to
-  *   log information about the retry attempts, or to perform other side effects. By default, the callback does nothing.
+  *   log information about the retry attempts, or to perform other side effects. It will always be invoked at least once (for a successful
+  *   operation run). By default, the callback does nothing.
   * @tparam E
   *   The error type of the operation. For operations returning a `T` or a `Try[T]`, this is fixed to `Throwable`. For operations returning
   *   an `Either[E, T]`, this can be any `E`.
@@ -38,92 +39,4 @@ case class RetryConfig[E, T](
 
     ScheduledConfig(schedule, afterAttempt, SleepMode.Delay)
   end toScheduledConfig
-end RetryConfig
-
-object RetryConfig:
-  /** Creates a config that retries up to a given number of times, with no delay between subsequent attempts, using a default
-    * [[ResultPolicy]].
-    *
-    * This is a shorthand for {{{RetryConfig(Schedule.Immediate(maxRetries))}}}
-    *
-    * @param maxRetries
-    *   The maximum number of retries.
-    */
-  def immediate[E, T](maxRetries: Int): RetryConfig[E, T] = RetryConfig(Schedule.Immediate(maxRetries))
-
-  /** Creates a config that retries indefinitely, with no delay between subsequent attempts, using a default [[ResultPolicy]].
-    *
-    * This is a shorthand for {{{RetryConfig(Schedule.Immediate.forever)}}}
-    */
-  def immediateForever[E, T]: RetryConfig[E, T] = RetryConfig(Schedule.Immediate.forever)
-
-  /** Creates a config that retries up to a given number of times, with a fixed delay between subsequent attempts, using a default
-    * [[ResultPolicy]].
-    *
-    * This is a shorthand for {{{RetryConfig(Schedule.Delay(maxRetries, delay))}}}
-    *
-    * @param maxRetries
-    *   The maximum number of retries.
-    * @param delay
-    *   The delay between subsequent attempts.
-    */
-  def delay[E, T](maxRetries: Int, delay: FiniteDuration): RetryConfig[E, T] = RetryConfig(Schedule.Fixed(maxRetries, delay))
-
-  /** Creates a config that retries indefinitely, with a fixed delay between subsequent attempts, using a default [[ResultPolicy]].
-    *
-    * This is a shorthand for {{{RetryConfig(Schedule.Delay.forever(delay))}}}
-    *
-    * @param delay
-    *   The delay between subsequent attempts.
-    */
-  def delayForever[E, T](delay: FiniteDuration): RetryConfig[E, T] = RetryConfig(Schedule.Fixed.forever(delay))
-
-  /** Creates a config that retries up to a given number of times, with an increasing delay (backoff) between subsequent attempts, using a
-    * default [[ResultPolicy]].
-    *
-    * The backoff is exponential with base 2 (i.e. the next delay is twice as long as the previous one), starting at the given initial delay
-    * and capped at the given maximum delay.
-    *
-    * This is a shorthand for {{{RetryConfig(Schedule.Backoff(maxRetries, initialDelay, maxDelay, jitter))}}}
-    *
-    * @param maxRetries
-    *   The maximum number of retries.
-    * @param initialDelay
-    *   The delay before the first retry.
-    * @param maxDelay
-    *   The maximum delay between subsequent retries. Defaults to 1 minute.
-    * @param jitter
-    *   A random factor used for calculating the delay between subsequent retries. See [[Jitter]] for more details. Defaults to no jitter,
-    *   i.e. an exponential backoff with no adjustments.
-    */
-  def backoff[E, T](
-      maxRetries: Int,
-      initialDelay: FiniteDuration,
-      maxDelay: FiniteDuration = 1.minute,
-      jitter: Jitter = Jitter.None
-  ): RetryConfig[E, T] =
-    RetryConfig(Schedule.Backoff(maxRetries, initialDelay, maxDelay, jitter))
-
-  /** Creates a config that retries indefinitely, with an increasing delay (backoff) between subsequent attempts, using a default
-    * [[ResultPolicy]].
-    *
-    * The backoff is exponential with base 2 (i.e. the next delay is twice as long as the previous one), starting at the given initial delay
-    * and capped at the given maximum delay.
-    *
-    * This is a shorthand for {{{RetryConfig(Schedule.Backoff.forever(initialDelay, maxDelay, jitter))}}}
-    *
-    * @param initialDelay
-    *   The delay before the first retry.
-    * @param maxDelay
-    *   The maximum delay between subsequent retries. Defaults to 1 minute.
-    * @param jitter
-    *   A random factor used for calculating the delay between subsequent retries. See [[Jitter]] for more details. Defaults to no jitter,
-    *   i.e. an exponential backoff with no adjustments.
-    */
-  def backoffForever[E, T](
-      initialDelay: FiniteDuration,
-      maxDelay: FiniteDuration = 1.minute,
-      jitter: Jitter = Jitter.None
-  ): RetryConfig[E, T] =
-    RetryConfig(Schedule.Backoff.forever(initialDelay, maxDelay, jitter))
 end RetryConfig

--- a/core/src/main/scala/ox/resilience/RetryConfig.scala
+++ b/core/src/main/scala/ox/resilience/RetryConfig.scala
@@ -37,6 +37,6 @@ case class RetryConfig[E, T](
         case Left(value)  => ScheduleStop(!resultPolicy.isWorthRetrying(value))
         case Right(value) => ScheduleStop(resultPolicy.isSuccess(value))
 
-    ScheduledConfig(schedule, afterAttempt, SleepMode.Delay)
+    ScheduledConfig(schedule, afterAttempt, SleepMode.EndToStart)
   end toScheduledConfig
 end RetryConfig

--- a/core/src/main/scala/ox/resilience/retry.scala
+++ b/core/src/main/scala/ox/resilience/retry.scala
@@ -1,35 +1,56 @@
 package ox.resilience
 
-import ox.{EitherMode, ErrorMode}
+import ox.EitherMode
+import ox.ErrorMode
 import ox.scheduling.*
 
 import scala.util.Try
 
 /** Retries an operation returning a direct result until it succeeds or the config decides to stop.
   *
-  * [[retry]] is a special case of [[scheduled]] with a given set of defaults. See [[RetryConfig]].
+  * [[retry]] is a special case of [[scheduled]] with a given set of defaults.
   *
   * @param config
-  *   The retry config - see [[RetryConfig]].
+  *   The retry config. Includes a [[Schedule]] which determines the intervals between invocations and number of attempts to execute the
+  *   operation.
   * @param operation
   *   The operation to retry.
   * @return
-  *   The result of the function if it eventually succeeds.
+  *   The result of the function when it eventually succeeds.
   * @throws anything
-  *   The exception thrown by the last attempt if the config decides to stop.
+  *   The exception thrown by the last attempt if the config decides to stop retrying.
   * @see
   *   [[scheduled]]
   */
 def retry[T](config: RetryConfig[Throwable, T])(operation: => T): T =
   retryEither(config)(Try(operation).toEither).fold(throw _, identity)
 
+/** Retries an operation returning a direct result until it succeeds or the schedule runs out. Uses the default [[RetryConfig]], with the
+  * given [[Schedule]].
+  *
+  * [[retry]] is a special case of [[scheduled]] with a given set of defaults.
+  *
+  * @param schedule
+  *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+  * @param operation
+  *   The operation to retry.
+  * @return
+  *   The result of the function when it eventually succeeds.
+  * @throws anything
+  *   The exception thrown by the last attempt if the config decides to stop retrying.
+  * @see
+  *   [[scheduled]]
+  */
+def retry[T](schedule: Schedule)(operation: => T): T = retry(RetryConfig(schedule))(operation)
+
 /** Retries an operation returning an [[scala.util.Either]] until it succeeds or the config decides to stop. Note that any exceptions thrown
   * by the operation aren't caught and don't cause a retry to happen.
   *
-  * [[retryEither]] is a special case of [[scheduledEither]] with a given set of defaults. See [[RetryConfig]] for more details.
+  * [[retryEither]] is a special case of [[scheduledEither]] with a given set of defaults.
   *
   * @param config
-  *   The retry config - see [[RetryConfig]].
+  *   The retry config. Includes a [[Schedule]] which determines the intervals between invocations and number of attempts to execute the
+  *   operation.
   * @param operation
   *   The operation to retry.
   * @return
@@ -40,16 +61,32 @@ def retry[T](config: RetryConfig[Throwable, T])(operation: => T): T =
 def retryEither[E, T](config: RetryConfig[E, T])(operation: => Either[E, T]): Either[E, T] =
   retryWithErrorMode(EitherMode[E])(config)(operation)
 
+/** Retries an operation returning an [[scala.util.Either]] until it succeeds or the config decides to stop. Note that any exceptions thrown
+  * by the operation aren't caught and don't cause a retry to happen. Uses the default [[RetryConfig]], with the given [[Schedule]].
+  *
+  * [[retryEither]] is a special case of [[scheduledEither]] with a given set of defaults.
+  *
+  * @param schedule
+  *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+  * @param operation
+  *   The operation to retry.
+  * @return
+  *   A [[scala.util.Right]] if the function eventually succeeds, or, otherwise, a [[scala.util.Left]] with the error from the last attempt.
+  * @see
+  *   [[scheduledEither]]
+  */
+def retryEither[E, T](schedule: Schedule)(operation: => Either[E, T]): Either[E, T] = retryEither(RetryConfig(schedule))(operation)
+
 /** Retries an operation using the given error mode until it succeeds or the config decides to stop. Note that any exceptions thrown by the
   * operation aren't caught (unless the operation catches them as part of its implementation) and don't cause a retry to happen.
   *
-  * [[retryWithErrorMode]] is a special case of [[scheduledWithErrorMode]] with a given set of defaults. See [[RetryConfig]] for more
-  * details.
+  * [[retryWithErrorMode]] is a special case of [[scheduledWithErrorMode]] with a given set of defaults.
   *
   * @param em
   *   The error mode to use, which specifies when a result value is considered success, and when a failure.
   * @param config
-  *   The retry config - see [[RetryConfig]].
+  *   The retry config. Includes a [[Schedule]] which determines the intervals between invocations and number of attempts to execute the
+  *   operation.
   * @param operation
   *   The operation to retry.
   * @return
@@ -61,3 +98,25 @@ def retryEither[E, T](config: RetryConfig[E, T])(operation: => Either[E, T]): Ei
   */
 def retryWithErrorMode[E, F[_], T](em: ErrorMode[E, F])(config: RetryConfig[E, T])(operation: => F[T]): F[T] =
   scheduledWithErrorMode(em)(config.toScheduledConfig)(operation)
+
+/** Retries an operation using the given error mode until it succeeds or the config decides to stop. Note that any exceptions thrown by the
+  * operation aren't caught (unless the operation catches them as part of its implementation) and don't cause a retry to happen. Uses the
+  * default [[RetryConfig]], with the given [[Schedule]].
+  *
+  * [[retryWithErrorMode]] is a special case of [[scheduledWithErrorMode]] with a given set of defaults.
+  *
+  * @param em
+  *   The error mode to use, which specifies when a result value is considered success, and when a failure.
+  * @param schedule
+  *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+  * @param operation
+  *   The operation to retry.
+  * @return
+  *   Either:
+  *   - the result of the function if it eventually succeeds, in the context of `F`, as dictated by the error mode.
+  *   - the error `E` in context `F` as returned by the last attempt if the config decides to stop.
+  * @see
+  *   [[scheduledWithErrorMode]]
+  */
+def retryWithErrorMode[E, F[_], T](em: ErrorMode[E, F])(schedule: Schedule)(operation: => F[T]): F[T] =
+  retryWithErrorMode(em)(RetryConfig(schedule))(operation)

--- a/core/src/main/scala/ox/scheduling/Jitter.scala
+++ b/core/src/main/scala/ox/scheduling/Jitter.scala
@@ -1,26 +1,9 @@
 package ox.scheduling
 
-/** A random factor used for calculating the delay between subsequent retries when a backoff strategy is used for calculating the delay.
-  *
-  * The purpose of jitter is to avoid clustering of subsequent retries, i.e. to reduce the number of clients calling a service exactly at
-  * the same time - which can result in subsequent failures, contrary to what you would expect from retrying. By introducing randomness to
-  * the delays, the retries become more evenly distributed over time.
-  *
-  * See the <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">AWS Architecture Blog article on backoff and
-  * jitter</a> for a more in-depth explanation.
-  *
-  * Depending on the algorithm, the jitter can affect the delay in different ways - see the concrete variants for more details.
-  */
 enum Jitter:
-  /** No jitter, i.e. the delay just uses an exponential backoff with no adjustments. */
-  case None
-
-  /** Full jitter, i.e. the delay is a random value between 0 and the calculated backoff delay. */
+  /** Full jitter, i.e. the delay is a random value between 0 and the interval. */
   case Full
 
-  /** Equal jitter, i.e. the delay is half of the calculated backoff delay plus a random value between 0 and the other half. */
+  /** Equal jitter, i.e. the delay is half of the interval plus a random value between 0 and the other half. */
   case Equal
-
-  /** Decorrelated jitter, i.e. the delay is a random value between the initial delay and the last delay multiplied by 3. */
-  case Decorrelated
 end Jitter

--- a/core/src/main/scala/ox/scheduling/RepeatConfig.scala
+++ b/core/src/main/scala/ox/scheduling/RepeatConfig.scala
@@ -1,8 +1,5 @@
 package ox.scheduling
 
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.duration.DurationInt
-
 /** A config that defines how to repeat an operation.
   *
   * [[Schedule]] provides the interval between subsequent invocations, which guarantees that the next operation will start no sooner than
@@ -13,8 +10,7 @@ import scala.concurrent.duration.DurationInt
   * [[ScheduledConfig.afterAttempt]] callback which checks if the result was successful.
   *
   * @param schedule
-  *   The repeat schedule which determines the maximum number of invocations and the interval between subsequent invocations. See
-  *   [[Schedule]] for more details.
+  *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
   * @param shouldContinueOnResult
   *   A function that determines whether to continue the loop after a success. The function receives the value that was emitted by the last
   *   invocation. Defaults to [[_ => true]].
@@ -36,107 +32,4 @@ case class RepeatConfig[E, T](
 
     ScheduledConfig(schedule, afterAttempt, SleepMode.Interval)
   end toScheduledConfig
-end RepeatConfig
-
-object RepeatConfig:
-  /** Creates a config that repeats up to a given number of times, with no interval between subsequent invocations and optional initial
-    * delay.
-    *
-    * @param maxInvocations
-    *   The maximum number of invocations.
-    * @param initialDelay
-    *   The initial delay before the first invocation.
-    */
-  def immediate[E, T](maxInvocations: Int, initialDelay: Option[FiniteDuration] = None): RepeatConfig[E, T] =
-    initialDelay match
-      case Some(delay) => RepeatConfig(Schedule.InitialDelay(delay).andThen(Schedule.Immediate(maxInvocations)))
-      case None        => RepeatConfig(Schedule.Immediate(maxInvocations))
-
-  /** Creates a config that repeats indefinitely, with no interval between subsequent invocations and optional initial delay.
-    *
-    * @param initialDelay
-    *   The initial delay before the first invocation.
-    */
-  def immediateForever[E, T](initialDelay: Option[FiniteDuration] = None): RepeatConfig[E, T] =
-    initialDelay match
-      case Some(delay) => RepeatConfig(Schedule.InitialDelay(delay).andThen(Schedule.Immediate.forever))
-      case None        => RepeatConfig(Schedule.Immediate.forever)
-
-  /** Creates a config that repeats up to a given number of times, with a fixed interval between subsequent invocations and optional initial
-    * delay.
-    *
-    * @param maxInvocations
-    *   The maximum number of invocations.
-    * @param interval
-    *   The interval between subsequent attempts.
-    * @param initialDelay
-    *   The initial delay before the first invocation.
-    */
-  def fixedRate[E, T](maxInvocations: Int, interval: FiniteDuration, initialDelay: Option[FiniteDuration] = None): RepeatConfig[E, T] =
-    initialDelay match
-      case Some(delay) => RepeatConfig(Schedule.InitialDelay(delay).andThen(Schedule.Fixed(maxInvocations, interval)))
-      case None        => RepeatConfig(Schedule.Fixed(maxInvocations, interval))
-
-  /** Creates a config that repeats indefinitely, with a fixed interval between subsequent invocations and optional initial delay.
-    *
-    * @param interval
-    *   The interval between subsequent invocations.
-    */
-  def fixedRateForever[E, T](interval: FiniteDuration, initialDelay: Option[FiniteDuration] = None): RepeatConfig[E, T] =
-    initialDelay match
-      case Some(delay) => RepeatConfig(Schedule.InitialDelay(delay).andThen(Schedule.Fixed.forever(interval)))
-      case None        => RepeatConfig(Schedule.Fixed.forever(interval))
-
-  /** Creates a config that repeats up to a given number of times, with an increasing interval (backoff) between subsequent attempts and
-    * optional initial delay.
-    *
-    * The backoff is exponential with base 2 (i.e. the next interval is twice as long as the previous one), starting at the given first
-    * interval and capped at the given maximum interval.
-    *
-    * @param maxInvocations
-    *   The maximum number of invocations.
-    * @param firstInterval
-    *   The interval between the first and the second operation.
-    * @param maxInterval
-    *   The maximum interval between subsequent invocations. Defaults to 1 minute.
-    * @param jitter
-    *   A random factor used for calculating the interval between subsequent retries. See [[Jitter]] for more details. Defaults to no
-    *   jitter, i.e. an exponential backoff with no adjustments.
-    */
-  def backoff[E, T](
-      maxInvocations: Int,
-      firstInterval: FiniteDuration,
-      maxInterval: FiniteDuration = 1.minute,
-      jitter: Jitter = Jitter.None,
-      initialDelay: Option[FiniteDuration] = None
-  ): RepeatConfig[E, T] =
-    initialDelay match
-      case Some(delay) =>
-        RepeatConfig(Schedule.InitialDelay(delay).andThen(Schedule.Backoff(maxInvocations, firstInterval, maxInterval, jitter)))
-      case None => RepeatConfig(Schedule.Backoff(maxInvocations, firstInterval, maxInterval, jitter))
-
-  /** Creates a config that repeats indefinitely, with an increasing interval (backoff) between subsequent invocations and optional initial
-    * delay.
-    *
-    * The backoff is exponential with base 2 (i.e. the next interval is twice as long as the previous one), starting at the given first
-    * interval and capped at the given maximum interval.
-    *
-    * @param firstInterval
-    *   The interval between the first and the second operation.
-    * @param maxInterval
-    *   The maximum interval between subsequent invocations. Defaults to 1 minute.
-    * @param jitter
-    *   A random factor used for calculating the interval between subsequent retries. See [[Jitter]] for more details. Defaults to no
-    *   jitter, i.e. an exponential backoff with no adjustments.
-    */
-  def backoffForever[E, T](
-      firstInterval: FiniteDuration,
-      maxInterval: FiniteDuration = 1.minute,
-      jitter: Jitter = Jitter.None,
-      initialDelay: Option[FiniteDuration] = None
-  ): RepeatConfig[E, T] =
-    initialDelay match
-      case Some(delay) =>
-        RepeatConfig(Schedule.InitialDelay(delay).andThen(Schedule.Backoff.forever(firstInterval, maxInterval, jitter)))
-      case None => RepeatConfig(Schedule.Backoff.forever(firstInterval, maxInterval, jitter))
 end RepeatConfig

--- a/core/src/main/scala/ox/scheduling/RepeatConfig.scala
+++ b/core/src/main/scala/ox/scheduling/RepeatConfig.scala
@@ -30,6 +30,6 @@ case class RepeatConfig[E, T](
         case Left(_)      => ScheduleStop.Yes
         case Right(value) => ScheduleStop(!shouldContinueOnResult(value))
 
-    ScheduledConfig(schedule, afterAttempt, SleepMode.Interval)
+    ScheduledConfig(schedule, afterAttempt, SleepMode.StartToStart)
   end toScheduledConfig
 end RepeatConfig

--- a/core/src/main/scala/ox/scheduling/Schedule.scala
+++ b/core/src/main/scala/ox/scheduling/Schedule.scala
@@ -12,10 +12,10 @@ import scala.util.Random
   *
   * @param intervals
   *   The intervals to use for the schedule.
-  * @param initialInterval
-  *   The interval to wait before running the operation for the first time - if any.
+  * @param initialDelay
+  *   The delay to wait before running the operation for the first time - if any.
   */
-case class Schedule(intervals: () => LazyList[FiniteDuration], initialInterval: Option[FiniteDuration] = None):
+case class Schedule(intervals: () => LazyList[FiniteDuration], initialDelay: Option[FiniteDuration] = None):
   /** Caps the intervals to the given maximum. */
   def maxInterval(max: FiniteDuration): Schedule = copy(intervals = () => intervals().map(_.min(max)))
 
@@ -56,12 +56,12 @@ case class Schedule(intervals: () => LazyList[FiniteDuration], initialInterval: 
   /** Modifies the schedule so that operations are only run after the initial given delay. Later, the intervals specified by the schedule
     * are used.
     */
-  def withInitialInterval(interval: FiniteDuration): Schedule = copy(initialInterval = Some(interval))
+  def withInitialDelay(interval: FiniteDuration): Schedule = copy(initialDelay = Some(interval))
 
-  /** Modifies the schedule so that the first invocation of the operation is run immediately, with subequent invocations following the
+  /** Modifies the schedule so that the first invocation of the operation is run immediately, with subsequent invocations following the
     * intervals specified by the schedule.
     */
-  def withNoInitialInterval(): Schedule = copy(initialInterval = None)
+  def withNoInitialDelay(): Schedule = copy(initialDelay = None)
 
   /** Combines two schedules. The second schedule will only be used if the first one is finite. */
   def andThen(other: Schedule): Schedule = copy(intervals = () => intervals() ++ other.intervals())

--- a/core/src/main/scala/ox/scheduling/Schedule.scala
+++ b/core/src/main/scala/ox/scheduling/Schedule.scala
@@ -3,176 +3,123 @@ package ox.scheduling
 import scala.concurrent.duration.*
 import scala.util.Random
 
-sealed trait Schedule:
-  def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration
-  def initialDelay: FiniteDuration = Duration.Zero
+/** Describes a schedule according to which [[ox.resilience.retry]], [[repeat]] and [[schedule]] will invoke operations. A schedule is
+  * essentially a list of intervals, which are used to determine how long to wait before subsequent invocations of the operation.
+  *
+  * Implementation note: the intervals lazy-list is lazy-evaluated itself, to avoid memory leaks when a schedule is captured as a value and
+  * used multiple times. The intervals list is re-created on every usage, which isn't optimal, but due to the small size (and gradual
+  * evaluation) of the list, should not cause any performance issues.
+  *
+  * @param intervals
+  *   The intervals to use for the schedule.
+  * @param initialInterval
+  *   The interval to wait before running the operation for the first time - if any.
+  */
+case class Schedule(intervals: () => LazyList[FiniteDuration], initialInterval: Option[FiniteDuration] = None):
+  /** Caps the intervals to the given maximum. */
+  def maxInterval(max: FiniteDuration): Schedule = copy(intervals = () => intervals().map(_.min(max)))
+
+  /** Caps the number of repeats to the given maximum, creating a finite schedule. */
+  def maxRepeats(max: Int): Schedule = copy(intervals = () => intervals().take(max))
+
+  /** Caps the total delay to the given maximum. The resulting schedule might still be infinite, if the intervals are originally 0. */
+  def maxRepeatsByCumulativeDelay(upTo: FiniteDuration): Schedule = copy(intervals = () =>
+    val d = intervals()
+    d
+      .scanLeft(0.seconds)((cumulative, next) => cumulative + next)
+      .zip(d)
+      .takeWhile(_._1 <= upTo)
+      .map(_._2))
+
+  /** Adds random jitter to each interval, using the provided jitter mode.
+    *
+    * The purpose of jitter is to avoid clustering of subsequent invocations, i.e. to reduce the number of clients calling a service exactly
+    * at the same time - which can result in failures, contrary to what you would expect e.g. when retrying. By introducing randomness to
+    * the delays, the repetitions become more evenly distributed over time.
+    *
+    * @see
+    *   <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">AWS Architecture Blog article on jitter</a>
+    *
+    * @see
+    *   [[Schedule.decorrelatedJitter]]
+    */
+  def jitter(j: Jitter = Jitter.Equal): Schedule = copy(intervals =
+    () =>
+      intervals().map: d =>
+        j match
+          case Jitter.Full => Random.between(0, d.toMillis).millis
+          case Jitter.Equal =>
+            val base = d.toMillis
+            (base / 2 + Random.between(0, base / 2)).millis
+  )
+
+  /** Modifies the schedule so that operations are only run after the initial given delay. Later, the intervals specified by the schedule
+    * are used.
+    */
+  def withInitialInterval(interval: FiniteDuration): Schedule = copy(initialInterval = Some(interval))
+
+  /** Modifies the schedule so that the first invocation of the operation is run immediately, with subequent invocations following the
+    * intervals specified by the schedule.
+    */
+  def withNoInitialInterval(): Schedule = copy(initialInterval = None)
+
+  /** Combines two schedules. The second schedule will only be used if the first one is finite. */
+  def andThen(other: Schedule): Schedule = copy(intervals = () => intervals() ++ other.intervals())
+
+  /** @see [[andThen]] */
+  def ++(other: Schedule): Schedule = andThen(other)
+end Schedule
 
 object Schedule:
+  /** An infinite schedule that immediately repeats the operation, without any delay. */
+  val immediate: Schedule = fixedInterval(0.seconds)
 
-  private[scheduling] sealed trait Finite extends Schedule:
-    def maxRepeats: Int
-    def andThen(nextSchedule: Finite): Finite = FiniteAndFiniteSchedules(this, nextSchedule)
-    def andThen(nextSchedule: Infinite): Infinite = FiniteAndInfiniteSchedules(this, nextSchedule)
+  /** An infinite schedule that repeats the operation at the given fixed interval. */
+  def fixedInterval(d: FiniteDuration): Schedule = Schedule(() => LazyList.continually(d))
 
-  private[scheduling] sealed trait Infinite extends Schedule
+  /** A finite schedule that repeats the operation at the given intervals, specified as a sequence of durations. */
+  def intervals(intervals: FiniteDuration*): Schedule = Schedule(() => LazyList.from(intervals))
 
-  /** @param computeNextDuration
-    *   computes time between next invocations of operation. Invocation = 0 represents initialDelay before invoking operation for the first
-    *   time.
-    */
-  private[scheduling] final case class ComputedInfinite(
-      computeNextDuration: (Int, Option[FiniteDuration]) => FiniteDuration
-  ) extends Infinite:
-    def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration = computeNextDuration(invocation, lastDuration)
+  /** An infinite, exponential backoff schedule with base 2. That is, each subsequent interval is twice as long as the previous one. */
+  def exponentialBackoff(initial: FiniteDuration): Schedule = Schedule(() =>
+    def loop(i: FiniteDuration): LazyList[FiniteDuration] = i #:: loop(capIntervalToMax(i * 2))
+    loop(initial)
+  )
 
-    override def initialDelay: FiniteDuration = computeNextDuration(0, None)
+  /** An infinite, Fibonacci backoff schedule. That is, each subsequent interval is the sum of the two previous intervals. */
+  def fibonacciBackoff(initial: FiniteDuration): Schedule = Schedule(() =>
+    def loop(i0: FiniteDuration, i1: FiniteDuration): LazyList[FiniteDuration] = i0 #:: loop(i1, capIntervalToMax(i0 + i1))
+    loop(initial, initial)
+  )
 
-  /** A schedule that represents an initial delay applied before the first invocation of operation being scheduled. Usually used in
-    * combination with other schedules using [[andThen]]
+  /** An infinite, decorrelated jitter schedule, where each interval is a random duration between the given minimum and three times the
+    * previous interval.
     *
-    * @param delay
-    *   The initial delay.
-    * @example
-    *   {{{
-    *   Schedule.InitialDelay(1.second).andThen(Schedule.Delay.forever(100.millis))
-    *   }}}
+    * @see
+    *   <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">AWS Architecture Blog article on jitter</a>
     */
-  case class InitialDelay(delay: FiniteDuration) extends Finite:
-    override def maxRepeats: Int = 0
-    override def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration =
-      Duration.Zero
-    override def initialDelay: FiniteDuration = delay
+  def decorrelatedJitter(min: FiniteDuration): Schedule = Schedule(() =>
+    val minAsMillis = min.toMillis
 
-  /** A schedule that represents an immediate invocation, up to a given number of times.
-    *
-    * @param maxRepeats
-    *   The maximum number of invocations.
-    */
-  case class Immediate(maxRepeats: Int) extends Finite:
-    override def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration =
-      Duration.Zero
+    def loop(previous: Long): LazyList[FiniteDuration] =
+      val next = Random.between(minAsMillis, previous * 3)
+      val nextDuration = capIntervalToMax(next.millis)
+      nextDuration #:: loop(nextDuration.toMillis)
 
-  object Immediate:
-    /** A schedule that represents an immediate invocation without any invocations limit */
-    def forever: Infinite = ImmediateForever
+    loop(minAsMillis)
+  )
 
-  private case object ImmediateForever extends Infinite:
-    override def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration =
-      Duration.Zero
+  /** An infinite computed schedule. Each interval is computed using the previously returned state (starting with the initial state). */
+  def computed[S](initialState: S, compute: S => (S, FiniteDuration)): Schedule = Schedule(() =>
+    def loop(s: S): LazyList[FiniteDuration] =
+      val (s2, i) = compute(s)
+      i #:: loop(s2)
 
-  /** A schedule that represents a fixed duration between invocations, up to a given number of times.
-    *
-    * @param maxRepeats
-    *   The maximum number of repeats.
-    * @param duration
-    *   The duration between subsequent invocations.
-    */
-  case class Fixed(maxRepeats: Int, duration: FiniteDuration) extends Finite:
-    override def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration = duration
+    loop(initialState)
+  )
 
-  object Fixed:
-    /** A schedule that represents a fixed duration between invocations without any invocations limit.
-      *
-      * @param duration
-      *   The duration between subsequent invocations.
-      */
-    def forever(duration: FiniteDuration): Infinite = FixedForever(duration)
-
-  private[scheduling] case class FixedForever(duration: FiniteDuration) extends Infinite:
-    override def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration = duration
-
-  /** A schedule that represents an increasing duration between invocations (backoff), up to a given number of times.
-    *
-    * The backoff is exponential with base 2 (i.e. the next duration is twice as long as the previous one), starting at the given first
-    * duration and capped at the given maximum duration.
-    *
-    * @param maxRepeats
-    *   The maximum number of repeats.
-    * @param firstDuration
-    *   The duration between the first and the second invocations.
-    * @param maxDuration
-    *   The maximum duration between subsequent invocations.
-    * @param jitter
-    *   A random factor used for calculating the duration between subsequent repeats. See [[Jitter]] for more details. Defaults to no
-    *   jitter, i.e. an exponential backoff with no adjustments.
-    */
-  case class Backoff(
-      maxRepeats: Int,
-      firstDuration: FiniteDuration,
-      maxDuration: FiniteDuration = 1.minute,
-      jitter: Jitter = Jitter.None
-  ) extends Finite:
-    override def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration =
-      Backoff.nextDuration(invocation, firstDuration, maxDuration, jitter, lastDuration)
-  end Backoff
-
-  object Backoff:
-    private[scheduling] def calculateDuration(invocation: Int, firstDuration: FiniteDuration, maxDuration: FiniteDuration): FiniteDuration =
-      // converting Duration <-> Long back and forth to avoid exceeding maximum duration
-      (firstDuration.toMillis * Math.pow(2, invocation)).toLong.min(maxDuration.toMillis).millis
-
-    private[scheduling] def nextDuration(
-        invocation: Int,
-        firstDuration: FiniteDuration,
-        maxDuration: FiniteDuration,
-        jitter: Jitter,
-        lastDuration: Option[FiniteDuration]
-    ): FiniteDuration =
-      def exponentialDuration = Backoff.calculateDuration(invocation, firstDuration, maxDuration)
-
-      jitter match
-        case Jitter.None => exponentialDuration
-        case Jitter.Full => Random.between(0, exponentialDuration.toMillis).millis
-        case Jitter.Equal =>
-          val backoff = exponentialDuration.toMillis
-          (backoff / 2 + Random.between(0, backoff / 2)).millis
-        case Jitter.Decorrelated =>
-          val last = lastDuration.getOrElse(firstDuration).toMillis
-          Random.between(firstDuration.toMillis, last * 3).millis
-      end match
-    end nextDuration
-
-    /** A schedule that represents an increasing duration between invocations (backoff) without any invocations limit.
-      *
-      * The backoff is exponential with base 2 (i.e. the next duration is twice as long as the previous one), starting at the given first
-      * duration and capped at the given maximum duration.
-      *
-      * @param firstDuration
-      *   The duration between the first and the second invocations.
-      * @param maxDuration
-      *   The maximum duration between subsequent repeats.
-      * @param jitter
-      *   A random factor used for calculating the duration between subsequent repeats. See [[Jitter]] for more details. Defaults to no
-      *   jitter, i.e. an exponential backoff with no adjustments.
-      */
-    def forever(firstDuration: FiniteDuration, maxDuration: FiniteDuration = 1.minute, jitter: Jitter = Jitter.None): Infinite =
-      BackoffForever(firstDuration, maxDuration, jitter)
-  end Backoff
-
-  private[scheduling] case class BackoffForever(
-      firstDuration: FiniteDuration,
-      maxDuration: FiniteDuration = 1.minute,
-      jitter: Jitter = Jitter.None
-  ) extends Infinite:
-    override def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration =
-      Backoff.nextDuration(invocation, firstDuration, maxDuration, jitter, lastDuration)
-
-  private[scheduling] sealed trait CombinedSchedules extends Schedule:
-    def first: Finite
-    def second: Schedule
-    override def nextDuration(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration =
-      if first.maxRepeats > invocation then first.nextDuration(invocation, lastDuration)
-      else second.nextDuration(invocation - first.maxRepeats, lastDuration)
-
-  /** A schedule that combines two schedules, using [[first]] first [[first.maxRepeats]] number of times, and then using [[second]]
-    * [[second.maxRepeats]] number of times.
-    */
-  private[scheduling] case class FiniteAndFiniteSchedules(first: Finite, second: Finite) extends CombinedSchedules, Finite:
-    override def maxRepeats: Int = first.maxRepeats + second.maxRepeats
-    override def initialDelay: FiniteDuration = first.initialDelay
-
-  /** A schedule that combines two schedules, using [[first]] first [[first.maxRepeats]] number of times, and then always using [[second]].
-    */
-  private[scheduling] case class FiniteAndInfiniteSchedules(first: Finite, second: Infinite) extends CombinedSchedules, Infinite:
-    override def initialDelay: FiniteDuration = first.initialDelay
+  private val intervalCap: FiniteDuration = (365 * 10).days // the maximum duration is ~292 years, capping way before we reach that
+  /* Caps the given interval to a maximum, to avoid exceptions when trying to represent too large intervals; these are most likely capped
+  by subsequent schedule transformations anyway - at least, they should be for the schedule to make sense. */
+  private def capIntervalToMax(i: FiniteDuration): FiniteDuration = if i > intervalCap then intervalCap else i
 end Schedule

--- a/core/src/main/scala/ox/scheduling/Schedule.scala
+++ b/core/src/main/scala/ox/scheduling/Schedule.scala
@@ -110,10 +110,11 @@ object Schedule:
   )
 
   /** An infinite computed schedule. Each interval is computed using the previously returned state (starting with the initial state). */
-  def computed[S](initialState: S, compute: S => (S, FiniteDuration)): Schedule = Schedule(() =>
+  def computed[S](initialState: S, compute: S => (S, Option[FiniteDuration])): Schedule = Schedule(() =>
     def loop(s: S): LazyList[FiniteDuration] =
-      val (s2, i) = compute(s)
-      i #:: loop(s2)
+      compute(s) match
+        case (s2, Some(i)) => i #:: loop(s2)
+        case (_, None)     => LazyList.empty[FiniteDuration] // no more intervals, stop the schedule
 
     loop(initialState)
   )

--- a/core/src/main/scala/ox/scheduling/repeat.scala
+++ b/core/src/main/scala/ox/scheduling/repeat.scala
@@ -1,16 +1,18 @@
 package ox.scheduling
 
+import ox.EitherMode
+import ox.ErrorMode
 import ox.scheduling.*
-import ox.{EitherMode, ErrorMode}
 
 import scala.util.Try
 
 /** Repeats an operation returning a direct result until it succeeds or the config decides to stop.
   *
-  * [[repeat]] is a special case of [[scheduled]] with a given set of defaults. See [[RepeatConfig]] for more details.
+  * [[repeat]] is a special case of [[scheduled]] with a given set of defaults.
   *
   * @param config
-  *   The repeat config - see [[RepeatConfig]].
+  *   The repeat config. Includes a [[Schedule]] which determines the intervals between invocations and number of repetitions of the
+  *   operation.
   * @param operation
   *   The operation to repeat.
   * @return
@@ -23,13 +25,32 @@ import scala.util.Try
 def repeat[T](config: RepeatConfig[Throwable, T])(operation: => T): T =
   repeatEither(config)(Try(operation).toEither).fold(throw _, identity)
 
+/** Repeats an operation returning a direct result until it succeeds or the config decides to stop. Uses the default [[RepeatConfig]], with
+  * the given [[Schedule]].
+  *
+  * [[repeat]] is a special case of [[scheduled]] with a given set of defaults.
+  *
+  * @param schedule
+  *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+  * @param operation
+  *   The operation to repeat.
+  * @return
+  *   The result of the last invocation if the config decides to stop.
+  * @throws anything
+  *   The exception thrown by the last invocation if the config decides to stop.
+  * @see
+  *   [[scheduled]]
+  */
+def repeat[T](schedule: Schedule)(operation: => T): T = repeat(RepeatConfig(schedule))(operation)
+
 /** Repeats an operation returning an [[scala.util.Either]] until the config decides to stop. Note that any exceptions thrown by the
   * operation aren't caught and effectively interrupt the repeat loop.
   *
-  * [[repeatEither]] is a special case of [[scheduledEither]] with a given set of defaults. See [[RepeatConfig]] for more details.
+  * [[repeatEither]] is a special case of [[scheduledEither]] with a given set of defaults.
   *
   * @param config
-  *   The repeat config - see [[RepeatConfig]].
+  *   The repeat config. Includes a [[Schedule]] which determines the intervals between invocations and number of repetitions of the
+  *   operation.
   * @param operation
   *   The operation to repeat.
   * @return
@@ -40,16 +61,32 @@ def repeat[T](config: RepeatConfig[Throwable, T])(operation: => T): T =
 def repeatEither[E, T](config: RepeatConfig[E, T])(operation: => Either[E, T]): Either[E, T] =
   repeatWithErrorMode(EitherMode[E])(config)(operation)
 
+/** Repeats an operation returning an [[scala.util.Either]] until the config decides to stop. Note that any exceptions thrown by the
+  * operation aren't caught and effectively interrupt the repeat loop. Uses the default [[RepeatConfig]], with the given [[Schedule]].
+  *
+  * [[repeatEither]] is a special case of [[scheduledEither]] with a given set of defaults.
+  *
+  * @param schedule
+  *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+  * @param operation
+  *   The operation to repeat.
+  * @return
+  *   The result of the last invocation if the config decides to stop.
+  * @see
+  *   [[scheduledEither]]
+  */
+def repeatEither[E, T](schedule: Schedule)(operation: => Either[E, T]): Either[E, T] = repeatEither(RepeatConfig(schedule))(operation)
+
 /** Repeats an operation using the given error mode until the config decides to stop. Note that any exceptions thrown by the operation
   * aren't caught and effectively interrupt the repeat loop.
   *
-  * [[repeatWithErrorMode]] is a special case of [[scheduledWithErrorMode]] with a given set of defaults. See [[RepeatConfig]] for more
-  * details.
+  * [[repeatWithErrorMode]] is a special case of [[scheduledWithErrorMode]] with a given set of defaults.
   *
   * @param em
   *   The error mode to use, which specifies when a result value is considered success, and when a failure.
   * @param config
-  *   The repeat config - see [[RepeatConfig]].
+  *   The repeat config. Includes a [[Schedule]] which determines the intervals between invocations and number of repetitions of the
+  *   operation.
   * @param operation
   *   The operation to repeat.
   * @return
@@ -59,3 +96,22 @@ def repeatEither[E, T](config: RepeatConfig[E, T])(operation: => Either[E, T]): 
   */
 def repeatWithErrorMode[E, F[_], T](em: ErrorMode[E, F])(config: RepeatConfig[E, T])(operation: => F[T]): F[T] =
   scheduledWithErrorMode[E, F, T](em)(config.toScheduledConfig)(operation)
+
+/** Repeats an operation using the given error mode until the config decides to stop. Note that any exceptions thrown by the operation
+  * aren't caught and effectively interrupt the repeat loop. Uses the default [[RepeatConfig]], with the given [[Schedule]].
+  *
+  * [[repeatWithErrorMode]] is a special case of [[scheduledWithErrorMode]] with a given set of defaults.
+  *
+  * @param em
+  *   The error mode to use, which specifies when a result value is considered success, and when a failure.
+  * @param schedule
+  *   The schedule which determines the intervals between invocations and number of attempts to execute the operation.
+  * @param operation
+  *   The operation to repeat.
+  * @return
+  *   The result of the last invocation if the config decides to stop.
+  * @see
+  *   [[scheduledWithErrorMode]]
+  */
+def repeatWithErrorMode[E, F[_], T](em: ErrorMode[E, F])(schedule: Schedule)(operation: => F[T]): F[T] =
+  repeatWithErrorMode[E, F, T](em)(RepeatConfig(schedule))(operation)

--- a/core/src/main/scala/ox/scheduling/scheduled.scala
+++ b/core/src/main/scala/ox/scheduling/scheduled.scala
@@ -129,7 +129,7 @@ def scheduledWithErrorMode[E, F[_], T](em: ErrorMode[E, F])(config: ScheduledCon
     end match
   end loop
 
-  config.schedule.initialInterval.foreach(sleep)
+  config.schedule.initialDelay.foreach(sleep)
 
   loop(1, config.schedule.intervals(), None)
 end scheduledWithErrorMode

--- a/core/src/main/scala/ox/scheduling/scheduled.scala
+++ b/core/src/main/scala/ox/scheduling/scheduled.scala
@@ -1,9 +1,12 @@
 package ox.scheduling
 
-import ox.{EitherMode, ErrorMode, sleep}
+import ox.EitherMode
+import ox.ErrorMode
+import ox.sleep
 
 import scala.annotation.tailrec
-import scala.concurrent.duration.{FiniteDuration, DurationLong}
+import scala.concurrent.duration.DurationLong
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 /** The mode that specifies how to interpret the duration provided by the schedule. */
@@ -33,7 +36,7 @@ object ScheduleStop:
   *   more details.
   * @param afterAttempt
   *   A callback invoked after every attempt, with the current invocation number (starting from 1) and the result of the operation. Might
-  *   decide to short-curcuit further attempts, and stop the schedule. Schedule configuration (e.g. max number of attempts) takes
+  *   decide to short-circuit further attempts, and stop the schedule. Schedule configuration (e.g. max number of attempts) takes
   *   precedence.
   * @param sleepMode
   *   The mode that specifies how to interpret the duration provided by the schedule. See [[SleepMode]] for more details.
@@ -90,46 +93,43 @@ def scheduledEither[E, T](config: ScheduledConfig[E, T])(operation: => Either[E,
   */
 def scheduledWithErrorMode[E, F[_], T](em: ErrorMode[E, F])(config: ScheduledConfig[E, T])(operation: => F[T]): F[T] =
   @tailrec
-  def loop(invocation: Int, remainingInvocations: Option[Int], lastDuration: Option[FiniteDuration]): F[T] =
-    def sleepIfNeeded(startTimestamp: Long) =
-      val nextDuration = config.schedule.nextDuration(invocation, lastDuration)
+  def loop(invocation: Int, intervals: LazyList[FiniteDuration], lastDuration: Option[FiniteDuration]): F[T] =
+    def sleepIfNeeded(startTimestamp: Long, nextDelay: FiniteDuration) =
       val delay = config.sleepMode match
         case SleepMode.Interval =>
           val elapsed = System.nanoTime() - startTimestamp
-          val remaining = nextDuration.toNanos - elapsed
+          val remaining = nextDelay.toNanos - elapsed
           remaining.nanos
-        case SleepMode.Delay => nextDuration
+        case SleepMode.Delay => nextDelay
       if delay.toMillis > 0 then sleep(delay)
       delay
     end sleepIfNeeded
 
     val startTimestamp = System.nanoTime()
+    val nextDelay = intervals.headOption
     operation match
       case v if em.isError(v) =>
         val error = em.getError(v)
         val shouldStop = config.afterAttempt(invocation, Left(error))
 
-        if remainingInvocations.forall(_ > 0) && !shouldStop.stop then
-          val delay = sleepIfNeeded(startTimestamp)
-          loop(invocation + 1, remainingInvocations.map(_ - 1), Some(delay))
-        else v
+        nextDelay match
+          case Some(nd) if !shouldStop.stop =>
+            val delay = sleepIfNeeded(startTimestamp, nd)
+            loop(invocation + 1, intervals.tail, Some(delay))
+          case _ => v
       case v =>
         val result = em.getT(v)
         val shouldStop = config.afterAttempt(invocation, Right(result))
 
-        if remainingInvocations.forall(_ > 0) && !shouldStop.stop then
-          val delay = sleepIfNeeded(startTimestamp)
-          loop(invocation + 1, remainingInvocations.map(_ - 1), Some(delay))
-        else v
+        nextDelay match
+          case Some(nd) if !shouldStop.stop =>
+            val delay = sleepIfNeeded(startTimestamp, nd)
+            loop(invocation + 1, intervals.tail, Some(delay))
+          case _ => v
     end match
   end loop
 
-  val remainingInvocations = config.schedule match
-    case finiteSchedule: Schedule.Finite => Some(finiteSchedule.maxRepeats)
-    case _                               => None
+  config.schedule.initialInterval.foreach(sleep)
 
-  val initialDelay = config.schedule.initialDelay
-  if initialDelay.toMillis > 0 then sleep(initialDelay)
-
-  loop(1, remainingInvocations, None)
+  loop(1, config.schedule.intervals(), None)
 end scheduledWithErrorMode

--- a/core/src/test/scala/ox/flow/reactive/FlowPublisherPekkoTest.scala
+++ b/core/src/test/scala/ox/flow/reactive/FlowPublisherPekkoTest.scala
@@ -9,7 +9,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import ox.*
 import ox.flow.Flow
-import ox.useInScope
 
 import scala.concurrent.duration.DurationInt
 

--- a/core/src/test/scala/ox/resilience/ImmediateRetryTest.scala
+++ b/core/src/test/scala/ox/resilience/ImmediateRetryTest.scala
@@ -10,7 +10,7 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
 
   behavior of "Immediate retry"
 
-  it should "retry a succeeding function" in {
+  it should "retry a succeeding function" in:
     // given
     var counter = 0
     val successfulResult = 42
@@ -20,18 +20,17 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
       successfulResult
 
     // when
-    val result = retry(RetryConfig.immediate(3))(f)
+    val result = retry(Schedule.immediate.maxRepeats(3))(f)
 
     // then
     result shouldBe successfulResult
     counter shouldBe 1
-  }
 
-  it should "fail fast when a function is not worth retrying" in {
+  it should "fail fast when a function is not worth retrying" in:
     // given
     var counter = 0
     val errorMessage = "boom"
-    val policy = RetryConfig[Throwable, Unit](Schedule.Immediate(3), ResultPolicy.retryWhen(_.getMessage != errorMessage))
+    val policy = RetryConfig[Throwable, Unit](Schedule.immediate.maxRepeats(3), ResultPolicy.retryWhen(_.getMessage != errorMessage))
 
     def f =
       counter += 1
@@ -40,13 +39,12 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
     // when/then
     the[RuntimeException] thrownBy retry(policy)(f) should have message errorMessage
     counter shouldBe 1
-  }
 
-  it should "retry a succeeding function with a custom success condition" in {
+  it should "retry a succeeding function with a custom success condition" in:
     // given
     var counter = 0
     val unsuccessfulResult = -1
-    val policy = RetryConfig[Throwable, Int](Schedule.Immediate(3), ResultPolicy.successfulWhen(_ > 0))
+    val policy = RetryConfig[Throwable, Int](Schedule.immediate.maxRepeats(3), ResultPolicy.successfulWhen(_ > 0))
 
     def f =
       counter += 1
@@ -58,9 +56,8 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
     // then
     result shouldBe unsuccessfulResult
     counter shouldBe 4
-  }
 
-  it should "retry a failing function" in {
+  it should "retry a failing function" in:
     // given
     var counter = 0
     val errorMessage = "boom"
@@ -70,11 +67,10 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
       if true then throw new RuntimeException(errorMessage)
 
     // when/then
-    the[RuntimeException] thrownBy retry(RetryConfig.immediate(3))(f) should have message errorMessage
+    the[RuntimeException] thrownBy retry(Schedule.immediate.maxRepeats(3))(f) should have message errorMessage
     counter shouldBe 4
-  }
 
-  it should "retry a failing function forever" in {
+  it should "retry a failing function forever" in:
     // given
     var counter = 0
     val retriesUntilSuccess = 10_000
@@ -85,14 +81,13 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
       if counter <= retriesUntilSuccess then throw new RuntimeException("boom") else successfulResult
 
     // when
-    val result = retry(RetryConfig.immediateForever)(f)
+    val result = retry(Schedule.immediate)(f)
 
     // then
     result shouldBe successfulResult
     counter shouldBe retriesUntilSuccess + 1
-  }
 
-  it should "retry a succeeding Either" in {
+  it should "retry a succeeding Either" in:
     // given
     var counter = 0
     val successfulResult = 42
@@ -102,18 +97,17 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
       Right(successfulResult)
 
     // when
-    val result = retryEither(RetryConfig.immediate(3))(f)
+    val result = retryEither(Schedule.immediate.maxRepeats(3))(f)
 
     // then
     result.value shouldBe successfulResult
     counter shouldBe 1
-  }
 
-  it should "fail fast when an Either is not worth retrying" in {
+  it should "fail fast when an Either is not worth retrying" in:
     // given
     var counter = 0
     val errorMessage = "boom"
-    val policy: RetryConfig[String, Int] = RetryConfig(Schedule.Immediate(3), ResultPolicy.retryWhen(_ != errorMessage))
+    val policy: RetryConfig[String, Int] = RetryConfig(Schedule.immediate.maxRepeats(3), ResultPolicy.retryWhen(_ != errorMessage))
 
     def f: Either[String, Int] =
       counter += 1
@@ -125,13 +119,12 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
     // then
     result.left.value shouldBe errorMessage
     counter shouldBe 1
-  }
 
-  it should "retry a succeeding Either with a custom success condition" in {
+  it should "retry a succeeding Either with a custom success condition" in:
     // given
     var counter = 0
     val unsuccessfulResult = -1
-    val policy: RetryConfig[String, Int] = RetryConfig(Schedule.Immediate(3), ResultPolicy.successfulWhen(_ > 0))
+    val policy: RetryConfig[String, Int] = RetryConfig(Schedule.immediate.maxRepeats(3), ResultPolicy.successfulWhen(_ > 0))
 
     def f: Either[String, Int] =
       counter += 1
@@ -143,9 +136,8 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
     // then
     result.value shouldBe unsuccessfulResult
     counter shouldBe 4
-  }
 
-  it should "retry a failing Either" in {
+  it should "retry a failing Either" in:
     // given
     var counter = 0
     val errorMessage = "boom"
@@ -155,16 +147,15 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
       Left(errorMessage)
 
     // when
-    val result = retryEither(RetryConfig.immediate(3))(f)
+    val result = retryEither(Schedule.immediate.maxRepeats(3))(f)
 
     // then
     result.left.value shouldBe errorMessage
     counter shouldBe 4
-  }
 
   behavior of "Adaptive retry with immediate config"
 
-  it should "retry a failing adaptive" in {
+  it should "retry a failing adaptive" in:
     // given
     var counter = 0
     val errorMessage = "boom"
@@ -176,14 +167,13 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
 
     val adaptive = AdaptiveRetry(TokenBucket(5), 1, 1)
     // when
-    val result = adaptive.retryEither(RetryConfig.immediate(5))(f)
+    val result = adaptive.retryEither(Schedule.immediate.maxRepeats(5))(f)
 
     // then
     result.value shouldBe "Success"
     counter shouldBe 3
-  }
 
-  it should "stop retrying after emptying bucket" in {
+  it should "stop retrying after emptying bucket" in:
     // given
     var counter = 0
     val errorMessage = "boom"
@@ -194,15 +184,14 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
 
     val adaptive = AdaptiveRetry(TokenBucket(2), 1, 1)
     // when
-    val result = adaptive.retryEither(RetryConfig.immediate[String, String](5))(f)
+    val result = adaptive.retryEither(Schedule.immediate.maxRepeats(5))(f)
 
     // then
     result.left.value shouldBe errorMessage
     // One for first try, two for retries with bucket size 2
     counter shouldBe 3
-  }
 
-  it should "not pay exceptionCost if result T is going to be retried and shouldPayPenaltyCost returns false" in {
+  it should "not pay exceptionCost if result T is going to be retried and shouldPayPenaltyCost returns false" in:
     // given
     var counter = 0
     val message = "success"
@@ -212,13 +201,13 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
       Right(message)
 
     val adaptive = AdaptiveRetry(TokenBucket(2), 1, 1)
-    val retryConfig = RetryConfig.immediate(5).copy(resultPolicy = ResultPolicy.successfulWhen[String, String](_ => false))
+    val retryConfig =
+      RetryConfig(Schedule.immediate.maxRepeats(5)).copy(resultPolicy = ResultPolicy.successfulWhen[String, String](_ => false))
     // when
     val result = adaptive.retryEither(retryConfig, _ => false)(f)
 
     // then
     result.value shouldBe message
     counter shouldBe 6
-  }
 
 end ImmediateRetryTest

--- a/core/src/test/scala/ox/resilience/OnRetryTest.scala
+++ b/core/src/test/scala/ox/resilience/OnRetryTest.scala
@@ -9,7 +9,7 @@ import ox.scheduling.Schedule
 class OnRetryTest extends AnyFlatSpec with Matchers with EitherValues with TryValues:
   behavior of "RetryPolicy onRetry callback"
 
-  it should "retry a succeeding function with onRetry callback" in {
+  it should "retry a succeeding function with onRetry callback" in:
     // given
     var onRetryInvocationCount = 0
 
@@ -26,7 +26,7 @@ class OnRetryTest extends AnyFlatSpec with Matchers with EitherValues with TryVa
       returnedResult = result
 
     // when
-    val result = retry(RetryConfig(Schedule.Immediate(3), onRetry = onRetry))(f)
+    val result = retry(RetryConfig(Schedule.immediate.maxRepeats(3), onRetry = onRetry))(f)
 
     // then
     result shouldBe successfulResult
@@ -34,9 +34,8 @@ class OnRetryTest extends AnyFlatSpec with Matchers with EitherValues with TryVa
 
     onRetryInvocationCount shouldBe 1
     returnedResult shouldBe Right(successfulResult)
-  }
 
-  it should "retry a failing function with onRetry callback" in {
+  it should "retry a failing function with onRetry callback" in:
     // given
     var onRetryInvocationCount = 0
 
@@ -53,7 +52,7 @@ class OnRetryTest extends AnyFlatSpec with Matchers with EitherValues with TryVa
       returnedResult = result
 
     // when
-    val result = the[RuntimeException] thrownBy retry(RetryConfig(Schedule.Immediate(3), onRetry = onRetry))(f)
+    val result = the[RuntimeException] thrownBy retry(RetryConfig(Schedule.immediate.maxRepeats(3), onRetry = onRetry))(f)
 
     // then
     result shouldBe failedResult
@@ -61,5 +60,4 @@ class OnRetryTest extends AnyFlatSpec with Matchers with EitherValues with TryVa
 
     onRetryInvocationCount shouldBe 4
     returnedResult shouldBe Left(failedResult)
-  }
 end OnRetryTest

--- a/core/src/test/scala/ox/scheduling/FixedRateRepeatTest.scala
+++ b/core/src/test/scala/ox/scheduling/FixedRateRepeatTest.scala
@@ -44,7 +44,7 @@ class FixedRateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (result, elapsedTime) = measure(repeat(Schedule.fixedInterval(interval).maxRepeats(repeats).withInitialInterval(initialDelay))(f))
+    val (result, elapsedTime) = measure(repeat(Schedule.fixedInterval(interval).maxRepeats(repeats).withInitialDelay(initialDelay))(f))
 
     // then
     elapsedTime.toMillis should be >= 3 * interval.toMillis + initialDelay.toMillis - 5 // tolerance
@@ -84,7 +84,7 @@ class FixedRateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
 
     // when
     val (ex, elapsedTime) =
-      measure(the[RuntimeException] thrownBy repeat(Schedule.fixedInterval(interval).withInitialInterval(initialDelay))(f))
+      measure(the[RuntimeException] thrownBy repeat(Schedule.fixedInterval(interval).withInitialDelay(initialDelay))(f))
 
     // then
     elapsedTime.toMillis should be >= 3 * interval.toMillis + initialDelay.toMillis - 5 // tolerance

--- a/core/src/test/scala/ox/scheduling/FixedRateRepeatTest.scala
+++ b/core/src/test/scala/ox/scheduling/FixedRateRepeatTest.scala
@@ -12,7 +12,7 @@ class FixedRateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
 
   behavior of "repeat"
 
-  it should "repeat a function at fixed rate" in {
+  it should "repeat a function at fixed rate" in:
     // given
     val repeats = 3
     val funcSleepTime = 30.millis
@@ -24,16 +24,15 @@ class FixedRateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (result, elapsedTime) = measure(repeat(RepeatConfig.fixedRate(repeats, interval))(f))
+    val (result, elapsedTime) = measure(repeat(Schedule.fixedInterval(interval).maxRepeats(repeats))(f))
 
     // then
     elapsedTime.toMillis should be >= 3 * interval.toMillis + funcSleepTime.toMillis - 5 // tolerance
     elapsedTime.toMillis should be < 4 * interval.toMillis
     result shouldBe 4
     counter shouldBe 4
-  }
 
-  it should "repeat a function at fixed rate with initial delay" in {
+  it should "repeat a function at fixed rate with initial delay" in:
     // given
     val repeats = 3
     val initialDelay = 50.millis
@@ -45,16 +44,15 @@ class FixedRateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (result, elapsedTime) = measure(repeat(RepeatConfig.fixedRate(repeats, interval, Some(initialDelay)))(f))
+    val (result, elapsedTime) = measure(repeat(Schedule.fixedInterval(interval).maxRepeats(repeats).withInitialInterval(initialDelay))(f))
 
     // then
     elapsedTime.toMillis should be >= 3 * interval.toMillis + initialDelay.toMillis - 5 // tolerance
     elapsedTime.toMillis should be < 4 * interval.toMillis
     result shouldBe 4
     counter shouldBe 4
-  }
 
-  it should "repeat a function forever at fixed rate" in {
+  it should "repeat a function forever at fixed rate" in:
     // given
     val interval = 100.millis
     var counter = 0
@@ -65,16 +63,15 @@ class FixedRateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (ex, elapsedTime) = measure(the[RuntimeException] thrownBy repeat(RepeatConfig.fixedRateForever(interval))(f))
+    val (ex, elapsedTime) = measure(the[RuntimeException] thrownBy repeat(Schedule.fixedInterval(interval))(f))
 
     // then
     elapsedTime.toMillis should be >= 3 * interval.toMillis - 5 // tolerance
     elapsedTime.toMillis should be < 4 * interval.toMillis
     ex.getMessage shouldBe "boom"
     counter shouldBe 4
-  }
 
-  it should "repeat a function forever at fixed rate with initial delay" in {
+  it should "repeat a function forever at fixed rate with initial delay" in:
     // given
     val initialDelay = 50.millis
     val interval = 100.millis
@@ -86,12 +83,12 @@ class FixedRateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (ex, elapsedTime) = measure(the[RuntimeException] thrownBy repeat(RepeatConfig.fixedRateForever(interval, Some(initialDelay)))(f))
+    val (ex, elapsedTime) =
+      measure(the[RuntimeException] thrownBy repeat(Schedule.fixedInterval(interval).withInitialInterval(initialDelay))(f))
 
     // then
     elapsedTime.toMillis should be >= 3 * interval.toMillis + initialDelay.toMillis - 5 // tolerance
     elapsedTime.toMillis should be < 4 * interval.toMillis
     ex.getMessage shouldBe "boom"
     counter shouldBe 4
-  }
 end FixedRateRepeatTest

--- a/core/src/test/scala/ox/scheduling/ImmediateRepeatTest.scala
+++ b/core/src/test/scala/ox/scheduling/ImmediateRepeatTest.scala
@@ -11,7 +11,7 @@ class ImmediateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
 
   behavior of "repeat"
 
-  it should "repeat a function immediately" in {
+  it should "repeat a function immediately" in:
     // given
     val repeats = 3
     var counter = 0
@@ -20,15 +20,14 @@ class ImmediateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (result, elapsedTime) = measure(repeat(RepeatConfig.immediate(repeats))(f))
+    val (result, elapsedTime) = measure(repeat(Schedule.immediate.maxRepeats(repeats))(f))
 
     // then
     elapsedTime.toMillis should be < 20L
     result shouldBe 4
     counter shouldBe 4
-  }
 
-  it should "repeat a function immediately with initial delay" in {
+  it should "repeat a function immediately with initial delay" in:
     // given
     val repeats = 3
     val initialDelay = 50.millis
@@ -39,16 +38,15 @@ class ImmediateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (result, elapsedTime) = measure(repeat(RepeatConfig.immediate(repeats, Some(initialDelay)))(f))
+    val (result, elapsedTime) = measure(repeat(Schedule.immediate.maxRepeats(repeats).withInitialInterval(initialDelay))(f))
 
     // then
     elapsedTime.toMillis should be >= initialDelay.toMillis
     elapsedTime.toMillis should be < initialDelay.toMillis + 20
     result shouldBe 4
     counter shouldBe 4
-  }
 
-  it should "repeat a function immediately forever" in {
+  it should "repeat a function immediately forever" in:
     // given
     var counter = 0
 
@@ -58,15 +56,14 @@ class ImmediateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (ex, elapsedTime) = measure(the[RuntimeException] thrownBy repeat(RepeatConfig.immediateForever())(f))
+    val (ex, elapsedTime) = measure(the[RuntimeException] thrownBy repeat(Schedule.immediate)(f))
 
     // then
     elapsedTime.toMillis should be < 20L
     ex.getMessage shouldBe "boom"
     counter shouldBe 4
-  }
 
-  it should "repeat a function immediately forever with initial delay" in {
+  it should "repeat a function immediately forever with initial delay" in:
     // given
     val initialDelay = 50.millis
     var counter = 0
@@ -77,12 +74,11 @@ class ImmediateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (ex, elapsedTime) = measure(the[RuntimeException] thrownBy repeat(RepeatConfig.immediateForever(Some(initialDelay)))(f))
+    val (ex, elapsedTime) = measure(the[RuntimeException] thrownBy repeat(Schedule.immediate.withInitialInterval(initialDelay))(f))
 
     // then
     elapsedTime.toMillis should be >= initialDelay.toMillis
     elapsedTime.toMillis should be < initialDelay.toMillis + 20
     ex.getMessage shouldBe "boom"
     counter shouldBe 4
-  }
 end ImmediateRepeatTest

--- a/core/src/test/scala/ox/scheduling/ImmediateRepeatTest.scala
+++ b/core/src/test/scala/ox/scheduling/ImmediateRepeatTest.scala
@@ -38,7 +38,7 @@ class ImmediateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (result, elapsedTime) = measure(repeat(Schedule.immediate.maxRepeats(repeats).withInitialInterval(initialDelay))(f))
+    val (result, elapsedTime) = measure(repeat(Schedule.immediate.maxRepeats(repeats).withInitialDelay(initialDelay))(f))
 
     // then
     elapsedTime.toMillis should be >= initialDelay.toMillis
@@ -74,7 +74,7 @@ class ImmediateRepeatTest extends AnyFlatSpec with Matchers with EitherValues wi
       counter
 
     // when
-    val (ex, elapsedTime) = measure(the[RuntimeException] thrownBy repeat(Schedule.immediate.withInitialInterval(initialDelay))(f))
+    val (ex, elapsedTime) = measure(the[RuntimeException] thrownBy repeat(Schedule.immediate.withInitialDelay(initialDelay))(f))
 
     // then
     elapsedTime.toMillis should be >= initialDelay.toMillis

--- a/cron/src/main/scala/ox/scheduling/cron/CronSchedule.scala
+++ b/cron/src/main/scala/ox/scheduling/cron/CronSchedule.scala
@@ -27,13 +27,12 @@ object CronSchedule:
     *   [[Schedule]] from cron expression
     */
   def fromCronExpr(cron: CronExpr): Schedule =
-    def computeNext: FiniteDuration =
-      val now = LocalDateTime.now()
-      val next = cron.next(now)
-      val duration = next.map(n => ChronoUnit.MILLIS.between(now, n))
+    def computeNext(previous: LocalDateTime): (LocalDateTime, Option[FiniteDuration]) =
+      val next = cron.next(previous)
+      val duration = next.map(n => ChronoUnit.MILLIS.between(previous, n).millis)
       println("COMPUTED " + duration)
-      duration.map(_.millis).getOrElse(Duration.Zero)
+      (next.getOrElse(previous), duration)
 
-    Schedule.computed((), _ => ((), computeNext))
+    Schedule.computed(LocalDateTime.now(), computeNext)
   end fromCronExpr
 end CronSchedule

--- a/cron/src/main/scala/ox/scheduling/cron/CronSchedule.scala
+++ b/cron/src/main/scala/ox/scheduling/cron/CronSchedule.scala
@@ -28,13 +28,12 @@ object CronSchedule:
     *   [[Schedule]] from cron expression
     */
   def fromCronExpr(cron: CronExpr): Schedule =
-    def computeNext(invocation: Int, lastDuration: Option[FiniteDuration]): FiniteDuration =
+    def computeNext: FiniteDuration =
       val now = LocalDateTime.now()
       val next = cron.next(now)
       val duration = next.map(n => ChronoUnit.MILLIS.between(now, n))
       duration.map(FiniteDuration.apply(_, TimeUnit.MILLISECONDS)).getOrElse(Duration.Zero)
-    end computeNext
 
-    Schedule.ComputedInfinite(computeNext)
+    Schedule.computed((), _ => ((), computeNext))
   end fromCronExpr
 end CronSchedule

--- a/cron/src/main/scala/ox/scheduling/cron/CronSchedule.scala
+++ b/cron/src/main/scala/ox/scheduling/cron/CronSchedule.scala
@@ -6,8 +6,7 @@ import ox.scheduling.Schedule
 
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.*
 
 /** Methods in this object provide [[Schedule]] based on supplied cron expression.
   */
@@ -32,7 +31,8 @@ object CronSchedule:
       val now = LocalDateTime.now()
       val next = cron.next(now)
       val duration = next.map(n => ChronoUnit.MILLIS.between(now, n))
-      duration.map(FiniteDuration.apply(_, TimeUnit.MILLISECONDS)).getOrElse(Duration.Zero)
+      println("COMPUTED " + duration)
+      duration.map(_.millis).getOrElse(Duration.Zero)
 
     Schedule.computed((), _ => ((), computeNext))
   end fromCronExpr

--- a/cron/src/main/scala/ox/scheduling/cron/CronSchedule.scala
+++ b/cron/src/main/scala/ox/scheduling/cron/CronSchedule.scala
@@ -30,7 +30,6 @@ object CronSchedule:
     def computeNext(previous: LocalDateTime): (LocalDateTime, Option[FiniteDuration]) =
       val next = cron.next(previous)
       val duration = next.map(n => ChronoUnit.MILLIS.between(previous, n).millis)
-      println("COMPUTED " + duration)
       (next.getOrElse(previous), duration)
 
     Schedule.computed(LocalDateTime.now(), computeNext)

--- a/doc/integrations/cron4s.md
+++ b/doc/integrations/cron4s.md
@@ -8,7 +8,7 @@ Dependency:
 
 This module allows to run schedules based on cron expressions from [cron4s](https://github.com/alonsodomin/cron4s).
 
-`CronSchedule` can be used in all places that requires `Schedule` especially in repeat scenarios.
+`CronSchedule` can be used in all places that requires `Schedule` especially in [repeat](../utils/repeat.md) scenarios.
 
 For defining `CronExpr` see [cron4s documentation](https://www.alonsodomin.me/cron4s/userguide/index.html).
 
@@ -20,7 +20,7 @@ The cron module exposes methods for creating `Schedule` based on `CronExpr`.
 import ox.scheduling.cron.*
 import cron4s.*
 
-repeat(RepeatConfig(CronSchedule.unsafeFromString("10-35 2,4,6 * ? * *")))(operation)
+repeat(CronSchedule.unsafeFromString("10-35 2,4,6 * ? * *"))(operation)
 ```
 
 ## Operation definition
@@ -50,8 +50,8 @@ def unionOperation: String | Int = ???
 val cronExpr: CronExpr = Cron.unsafeParse("10-35 2,4,6 * ? * *")
 
 // various operation definitions - same syntax
-repeat(RepeatConfig(CronSchedule.fromCronExpr(cronExpr)))(directOperation)
-repeatEither(RepeatConfig(CronSchedule.fromCronExpr(cronExpr)))(eitherOperation)
+repeat(CronSchedule.fromCronExpr(cronExpr))(directOperation)
+repeatEither(CronSchedule.fromCronExpr(cronExpr))(eitherOperation)
 
 // infinite repeats with a custom strategy
 def customStopStrategy: Int => Boolean = ???
@@ -62,6 +62,6 @@ repeatWithErrorMode(UnionMode[String])(RepeatConfig(CronSchedule.fromCronExpr(cr
 
 // repeat with retry inside
 repeat(RepeatConfig(CronSchedule.fromCronExpr(cronExpr))) {
-  retry(RetryConfig.backoff(3, 100.millis))(directOperation)
+  retry(Schedule.exponentialBackoff(100.millis).maxRepeats(3))(directOperation)
 }
 ```

--- a/doc/tour.md
+++ b/doc/tour.md
@@ -67,14 +67,15 @@ supervised {
 
 ```scala mdoc:compile-only
 def computationR: Int = ???
-retry(RetryConfig.backoff(3, 100.millis, 5.minutes, Jitter.Equal))(computationR)
+retry(Schedule.exponentialBackoff(100.millis).maxRepeats(5)
+  .jitter().maxInterval(5.minutes))(computationR)
 ```
 
 [Repeat](utils/repeat.md) a computation:
 
 ```scala mdoc:compile-only
 def computationR: Int = ???
-repeat(RepeatConfig.fixedRateForever(100.millis))(computationR)
+repeat(Schedule.fixedInterval(100.millis))(computationR)
 ```
 
 [Rate limit](utils/rate-limiter.md) computations:

--- a/doc/utils/circuit-breaker.md
+++ b/doc/utils/circuit-breaker.md
@@ -128,8 +128,9 @@ This can be the case with many very fast operations.
 
 ```scala mdoc:compile-only
 import ox.UnionMode
-import ox.supervised
 import ox.resilience.*
+import ox.scheduling.Schedule
+import ox.supervised
 import scala.concurrent.duration.*
 
 def directOperation: Int = ???
@@ -147,7 +148,7 @@ supervised:
   circuitBreaker.runOrDropWithErrorMode(UnionMode[String])(unionOperation)
 
   // retry with circuit breaker inside
-  retryEither(RetryConfig.backoff(3, 100.millis)){
+  retryEither(Schedule.exponentialBackoff(100.millis).maxRepeats(3)){
     circuitBreaker.runOrDrop(directOperation) match
       case Some(value) => Right(value)
       case None => Left("Operation dropped")

--- a/doc/utils/repeat.md
+++ b/doc/utils/repeat.md
@@ -10,14 +10,15 @@ The basic syntax for `repeat` is:
 ```scala
 import ox.scheduling.repeat
 
-repeat(config)(operation)
+repeat(schedule)(operation)
 ```
 
 The `repeat` API uses `scheduled` underneath with DSL focused on repeats. See [scheduled](scheduled.md) for more details.
 
 ## Operation definition
 
-Similarly to the `retry` API, the `operation` can be defined: 
+Similarly to the [retry](retries.md) API, the `operation` can be defined: 
+
 * directly using a by-name parameter, i.e. `f: => T`
 * using a by-name `Either[E, T]`
 * or using an arbitrary [error mode](../basics/error-handling.md), accepting the computation in an `F` context: `f: => F[T]`.
@@ -34,17 +35,10 @@ If an operation returns an error, the repeat loop will always be stopped. If an 
 is needed, you can use a `retry` inside it (see an example below) or use `scheduled` instead of `repeat`, which allows
 full customization.
 
-### API shorthands
+This is captured as a `RepeatConfig` instance. For convenience, the `repeat` method accepts either a full `RepeatConfig`, 
+or just the `Schedule`. In the latter case, a default `RepeatConfig` is created, using the schedule.
 
-You can use one of the following shorthands to define a `RepeatConfig` with a given schedule with an optional initial delay:
-- `RepeatConfig.immediate(maxInvocations: Int, initialDelay: Option[FiniteDuration] = None)`
-- `RepeatConfig.immediateForever[E, T](initialDelay: Option[FiniteDuration] = None)`
-- `RepeatConfig.fixedRate[E, T](maxInvocations: Int, interval: FiniteDuration, initialDelay: Option[FiniteDuration] = None)`
-- `RepeatConfig.fixedRateForever[E, T](interval: FiniteDuration, initialDelay: Option[FiniteDuration] = None)`
-- `RepeatConfig.backoff[E, T](maxInvocations: Int, firstInterval: FiniteDuration, maxInterval: FiniteDuration = 1.minute, jitter: Jitter = Jitter.None, initialDelay: Option[FiniteDuration] = None)`
-- `RepeatConfig.backoffForever[E, T](firstInterval: FiniteDuration, maxInterval: FiniteDuration = 1.minute, jitter: Jitter = Jitter.None, initialDelay: Option[FiniteDuration] = None)`
-
-See [scheduled](scheduled.md) for details on how to create custom schedules.
+The [retry](retries.md) documentation includes an overview of the available ways to create and modify a `Schedule`.
 
 ## Examples
 
@@ -59,22 +53,25 @@ def eitherOperation: Either[String, Int] = ???
 def unionOperation: String | Int = ???
 
 // various operation definitions - same syntax
-repeat(RepeatConfig.immediate(3))(directOperation)
-repeatEither(RepeatConfig.immediate(3))(eitherOperation)
+repeat(Schedule.immediate.maxRepeats(3))(directOperation)
+repeatEither(Schedule.immediate.maxRepeats(3))(eitherOperation)
 
 // various schedules
-repeat(RepeatConfig.fixedRate(3, 100.millis))(directOperation)
-repeat(RepeatConfig.fixedRate(3, 100.millis, Some(50.millis)))(directOperation)
+repeat(Schedule.fixedInterval(100.millis).maxRepeats(3))(directOperation)
+repeat(Schedule.fixedInterval(100.millis).maxRepeats(3).withInitialInterval(50.millis))(
+  directOperation)
 
 // infinite repeats with a custom strategy
 def customStopStrategy: Int => Boolean = ???
-repeat(RepeatConfig.fixedRateForever(100.millis).copy(shouldContinueOnResult = customStopStrategy))(directOperation)
+repeat(RepeatConfig(Schedule.fixedInterval(100.millis))
+  .copy(shouldContinueOnResult = customStopStrategy))(directOperation)
 
 // custom error mode
-repeatWithErrorMode(UnionMode[String])(RepeatConfig.fixedRate(3, 100.millis))(unionOperation)
+repeatWithErrorMode(UnionMode[String])(Schedule.fixedInterval(100.millis).maxRepeats(3))(
+  unionOperation)
 
 // repeat with retry inside
-repeat(RepeatConfig.fixedRate(3, 100.millis)) {
-  retry(RetryConfig.backoff(3, 100.millis))(directOperation)
+repeat(Schedule.fixedInterval(100.millis).maxRepeats(3)) {
+  retry(Schedule.exponentialBackoff(100.millis).maxRepeats(3))(directOperation)
 }
 ```

--- a/doc/utils/repeat.md
+++ b/doc/utils/repeat.md
@@ -58,7 +58,7 @@ repeatEither(Schedule.immediate.maxRepeats(3))(eitherOperation)
 
 // various schedules
 repeat(Schedule.fixedInterval(100.millis).maxRepeats(3))(directOperation)
-repeat(Schedule.fixedInterval(100.millis).maxRepeats(3).withInitialInterval(50.millis))(
+repeat(Schedule.fixedInterval(100.millis).maxRepeats(3).withInitialDelay(50.millis))(
   directOperation)
 
 // infinite repeats with a custom strategy

--- a/doc/utils/retries.md
+++ b/doc/utils/retries.md
@@ -56,8 +56,8 @@ The schedules can be then customized using methods which include the following:
 - `.maxInterval(maxInterval: FiniteDuration)` 
 - `.jitter(jitter: Jitter)` 
 - `.maxRepeatsByCumulativeDelay(upTo: FiniteDuration)`
-- `.withInitialInterval(interval: FiniteDuration)`
-- `.withNoInitialInterval()`
+- `.withInitialDelay(interval: FiniteDuration)`
+- `.withNoInitialDelay()`
 - `.andThen(other: Schedule)`
 
 See [scheduled](scheduled.md) for details on how to create custom schedules.

--- a/doc/utils/retries.md
+++ b/doc/utils/retries.md
@@ -48,7 +48,7 @@ Schedules can be created using one of the following methods on the companion obj
 - `Schedule.exponentialBackoff(initialDelay: FiniteDuration)`,
 - `Schedule.fibonacciBackoff(initialDelay: FiniteDuration)`,
 - `Schedule.decorrelatedJitter(min: FiniteDuration)`,
-- `Schedule.computed[S](initialState: S, compute: S => (S, FiniteDuration))`
+- `Schedule.computed[S](initialState: S, compute: S => (S, Option[FiniteDuration]))`
 
 The schedules can be then customized using methods which include the following:
 

--- a/doc/utils/retries.md
+++ b/doc/utils/retries.md
@@ -10,7 +10,7 @@ The basic syntax for retries is:
 ```scala
 import ox.resilience.retry
 
-retry(config)(operation)
+retry(schedule)(operation)
 ```
 
 The `retry` API uses `scheduled` underneath with DSL focused on retries. See [scheduled](scheduled.md) for more details.
@@ -24,7 +24,7 @@ which accepts arbitrary [error modes](../basics/error-handling.md), accepting th
 
 ## Configuration
 
-A retry config consists of three parts:
+Retries can be configured using a `RetryConfig` instance, which consists of three parts:
 
 - a `Schedule`, which indicates how many times and with what delay should we retry the `operation` after an initial
   failure,
@@ -34,6 +34,33 @@ A retry config consists of three parts:
     - an erroneous outcome of the `operation` should be retried or fail fast.
 - a `onRetry`, which is a callback function that is invoked after each attempt to execute the operation. It is used to
   perform any necessary actions or checks after each attempt, regardless of whether the attempt was successful or not.
+
+For convenience, the `retry` method accepts either a full `RetryConfig`, or just the `Schedule`. In the latter case, a
+default `RetryConfig` is created, using the schedule.
+
+### Schedules
+
+Schedules can be created using one of the following methods on the companion object, including:
+
+- `Schedule.immediate`,
+- `Schedule.fixedInterval(interval: FiniteDuration)`,
+- `Schedule.intervals(intervals: FiniteDuration*)`,
+- `Schedule.exponentialBackoff(initialDelay: FiniteDuration)`,
+- `Schedule.fibonacciBackoff(initialDelay: FiniteDuration)`,
+- `Schedule.decorrelatedJitter(min: FiniteDuration)`,
+- `Schedule.computed[S](initialState: S, compute: S => (S, FiniteDuration))`
+
+The schedules can be then customized using methods which include the following:
+
+- `.maxRepeats(maxRetries: Int)`
+- `.maxInterval(maxInterval: FiniteDuration)` 
+- `.jitter(jitter: Jitter)` 
+- `.maxRepeatsByCumulativeDelay(upTo: FiniteDuration)`
+- `.withInitialInterval(interval: FiniteDuration)`
+- `.withNoInitialInterval()`
+- `.andThen(other: Schedule)`
+
+See [scheduled](scheduled.md) for details on how to create custom schedules.
 
 ### Result policies
 
@@ -52,6 +79,15 @@ The `ResultPolicy[E, T]` is generic both over the error (`E`) and result (`T`) t
 variant `retry`, the error type `E` is fixed to `Throwable`, while for the `Either` and error-mode variants, `E` can ba
 an arbitrary type.
 
+If you want to customize a part of the result policy, you can use the following shorthands:
+
+- `ResultPolicy.default[E, T]` - uses the default settings,
+- `ResultPolicy.successfulWhen[E, T](isSuccess: T => Boolean)` - uses the default `isWorthRetrying` and the
+  provided `isSuccess`,
+- `ResultPolicy.retryWhen[E, T](isWorthRetrying: E => Boolean)` - uses the default `isSuccess` and the
+  provided `isWorthRetrying`,
+- `ResultPolicy.neverRetry[E, T]` - uses the default `isSuccess` and fails fast on any error.
+
 ### On retry
 
 The callback function has the following signature:
@@ -65,29 +101,6 @@ Where:
 - The second parameter is an `Either[E, T]` type, representing the result of the retry operation. Left represents an
   error and Right represents a successful result.
 
-### API shorthands
-
-When you don't need to customize the result policy (i.e. use the default one) or use complex schedules,
-you can use one of the following shorthands to define a retry config with a given schedule:
-
-- `RetryConfig.immediate(maxRetries: Int)`,
-- `RetryConfig.immediateForever`,
-- `RetryConfig.delay(maxRetries: Int, delay: FiniteDuration)`,
-- `RetryConfig.delayForever(delay: FiniteDuration)`,
-- `RetryConfig.backoff(maxRetries: Int, initialDelay: FiniteDuration, maxDelay: FiniteDuration, jitter: Jitter)`,
-- `RetryConfig.backoffForever(initialDelay: FiniteDuration, maxDelay: FiniteDuration, jitter: Jitter)`.
-
-See [scheduled](scheduled.md) for details on how to create custom schedules.
-
-If you want to customize a part of the result policy, you can use the following shorthands:
-
-- `ResultPolicy.default[E, T]` - uses the default settings,
-- `ResultPolicy.successfulWhen[E, T](isSuccess: T => Boolean)` - uses the default `isWorthRetrying` and the
-  provided `isSuccess`,
-- `ResultPolicy.retryWhen[E, T](isWorthRetrying: E => Boolean)` - uses the default `isSuccess` and the
-  provided `isWorthRetrying`,
-- `ResultPolicy.neverRetry[E, T]` - uses the default `isSuccess` and fails fast on any error.
-
 ## Examples
 
 ```scala mdoc:compile-only
@@ -100,38 +113,46 @@ def directOperation: Int = ???
 def eitherOperation: Either[String, Int] = ???
 def unionOperation: String | Int = ???
 
-// various operation definitions - same syntax
-retry(RetryConfig.immediate(3))(directOperation)
-retryEither(RetryConfig.immediate(3))(eitherOperation)
+// various operation signatures/error modes - same syntax
+retry(Schedule.immediate.maxRepeats(3))(directOperation)
+retryEither(Schedule.immediate.maxRepeats(3))(eitherOperation)
 
 // various configs with custom schedules and default ResultPolicy
-retry(RetryConfig.delay(3, 100.millis))(directOperation)
-retry(RetryConfig.backoff(3, 100.millis))(directOperation) // defaults: maxDelay = 1.minute, jitter = Jitter.None
-retry(RetryConfig.backoff(3, 100.millis, 5.minutes, Jitter.Equal))(directOperation)
+retry(Schedule.fixedInterval(100.millis).maxRepeats(3))(directOperation)
+retry(Schedule.exponentialBackoff(100.millis).maxRepeats(3))(directOperation) 
+retry(Schedule.exponentialBackoff(100.millis).maxRepeats(3).jitter().maxInterval(5.minutes))(
+  directOperation)
 
 // infinite retries with a default ResultPolicy
-retry(RetryConfig.delayForever(100.millis))(directOperation)
-retry(RetryConfig.backoffForever(100.millis, 5.minutes, Jitter.Full))(directOperation)
+retry(Schedule.fixedInterval(100.millis))(directOperation)
+retry(Schedule.exponentialBackoff(100.millis).jitter(Jitter.Full).maxInterval(5.minutes))(
+  directOperation)
 
 // result policies
 // custom success
-retry[Int](RetryConfig(Schedule.Immediate(3), ResultPolicy.successfulWhen(_ > 0)))(directOperation)
+retry(RetryConfig[Throwable, Int](
+  Schedule.immediate.maxRepeats(3), ResultPolicy.successfulWhen(_ > 0)))(directOperation)
 // fail fast on certain errors
-retry(RetryConfig(Schedule.Immediate(3), ResultPolicy.retryWhen(_.getMessage != "fatal error")))(directOperation)
-retryEither(RetryConfig(Schedule.Immediate(3), ResultPolicy.retryWhen(_ != "fatal error")))(eitherOperation)
+retry(RetryConfig[Throwable, Int](
+  Schedule.immediate.maxRepeats(3), ResultPolicy.retryWhen(_.getMessage != "fatal error")))(
+    directOperation)
+retryEither(RetryConfig(
+  Schedule.immediate.maxRepeats(3), ResultPolicy.retryWhen(_ != "fatal error")))(
+    eitherOperation)
 
 // custom error mode
-retryWithErrorMode(UnionMode[String])(
-  RetryConfig(Schedule.Immediate(3), ResultPolicy.retryWhen(_ != "fatal error")))(unionOperation)
+retryWithErrorMode(UnionMode[String])(RetryConfig[String, Int](
+  Schedule.immediate.maxRepeats(3), ResultPolicy.retryWhen(_ != "fatal error")))(
+    unionOperation)
 ```
 
 See the tests in `ox.resilience.*` for more.
 
 ## Adaptive retries
 
-A retry strategy, backed by a token bucket. Every retry costs a certain amount of tokens from the bucket, and every success causes some tokens to be added back to the bucket. If there are not enought tokens, retry is not attempted.
+A retry strategy, backed by a token bucket. Every retry costs a certain amount of tokens from the bucket, and every success causes some tokens to be added back to the bucket. If there are not enough tokens, retry is not attempted.
   
-This way retries don't overload a system that is down due to a systemic failure (such as a bug in the code, excessive load etc.): retries will be attempted only as long as there are enought tokens in the bucket, then the load on the downstream system will be reduced so that it can recover. In contrast, using a "normal" retry strategy, where every operation is retries up to 3 times, a failure causes the load on the system to increas 4 times.
+This way retries don't overload a system that is down due to a systemic failure (such as a bug in the code, excessive load etc.): retries will be attempted only as long as there are enough tokens in the bucket, then the load on the downstream system will be reduced so that it can recover. In contrast, using a "normal" retry strategy, where every operation is retries up to 3 times, a failure causes the load on the system to increase 4 times.
 
 For transient failures (component failure, infrastructure issues etc.), retries still work "normally", as the bucket has enough tokens to cover the cost of multiple retries.
 
@@ -146,11 +167,11 @@ To use adaptive retries, create an instance of `AdaptiveRetry`. These instances 
 
 `AdaptiveRetry` is parametrized with:
 
-* `tokenBucket: Tokenbucket`: instances of `TokenBucket` can be shared across multiple instances of `AdaptiveRetry`
+* `tokenBucket: TokenBucket`: instances of `TokenBucket` can be shared across multiple instances of `AdaptiveRetry`
 * `failureCost: Int`: number of tokens that are needed for retry in case of failure
 * `successReward: Int`: number of tokens that are added back to token bucket after success
 
-`RetryConfig` and `ResultPolicy` are defined the same as with "normal" retry mechanism, all the configuration from above also applies here.
+`RetryConfig` (including the `Schedule` and `ResultPolicy`) is defined the same as with "normal" retry mechanism, all the configuration from above also applies here.
 
 Instance with default configuration can be obtained with `AdaptiveRetry.default` (bucket size = 500, cost for failure = 5 and reward for success = 1).
 
@@ -158,7 +179,7 @@ Instance with default configuration can be obtained with `AdaptiveRetry.default`
 
 `AdaptiveRetry` exposes three variants of retrying, which correspond to the three variants discussed above: `retry`, `retryEither` and `retryWithErrorMode`.
 
-`retry` will attempt to retry an operation if it throws an exception; `retryEither` will additionally retry, if the result is a `Left`. Finally `retryWithErrorMode` is the most flexible, and allows retrying operations using custom failure modes (such as union types).
+`retry` will attempt to retry an operation if it throws an exception; `retryEither` will retry, if the result is a `Left`. Finally `retryWithErrorMode` is the most flexible, and allows retrying operations using custom failure modes (such as union types).
 
 The methods have an additional parameter, `shouldPayPenaltyCost`, which determines if result `Either[E, T]` should be considered as a failure in terms of paying cost for retry. Penalty is paid only if it is decided to retry operation, the penalty will not be paid for successful operation.
 
@@ -180,27 +201,31 @@ def unionOperation: String | Int = ???
 val adaptive = AdaptiveRetry.default
 
 // various configs with custom schedules and default ResultPolicy
-adaptive.retry(RetryConfig.immediate(3))(directOperation)
-adaptive.retry(RetryConfig.delay(3, 100.millis))(directOperation)
-adaptive.retry(RetryConfig.backoff(3, 100.millis))(directOperation) // defaults: maxDelay = 1.minute, jitter = Jitter.None
-adaptive.retry(RetryConfig.backoff(3, 100.millis, 5.minutes, Jitter.Equal))(directOperation)
+adaptive.retry(Schedule.immediate.maxRepeats(3))(directOperation)
+adaptive.retry(Schedule.fixedInterval(100.millis).maxRepeats(3))(directOperation)
+adaptive.retry(Schedule.exponentialBackoff(100.millis).maxRepeats(3))(directOperation)
+adaptive.retry(Schedule.exponentialBackoff(100.millis).maxRepeats(3).jitter()
+  .maxInterval(5.minutes))(directOperation)
 
 // result policies
 // custom success
-adaptive.retry[Int](
-  RetryConfig(Schedule.Immediate(3), ResultPolicy.successfulWhen(_ > 0)))(directOperation)
+adaptive.retry(RetryConfig[Throwable, Int](
+  Schedule.immediate.maxRepeats(3), ResultPolicy.successfulWhen(_ > 0)))(directOperation)
 // fail fast on certain errors
-adaptive.retry(
-  RetryConfig(Schedule.Immediate(3), ResultPolicy.retryWhen(_.getMessage != "fatal error")))(directOperation)
-adaptive.retryEither(
-  RetryConfig(Schedule.Immediate(3), ResultPolicy.retryWhen(_ != "fatal error")))(eitherOperation)
+adaptive.retry(RetryConfig[Throwable, Int](
+  Schedule.immediate.maxRepeats(3), ResultPolicy.retryWhen(_.getMessage != "fatal error")))(
+    directOperation)
+adaptive.retryEither(RetryConfig(
+  Schedule.immediate.maxRepeats(3), ResultPolicy.retryWhen(_ != "fatal error")))(
+    eitherOperation)
 
 // custom error mode 
-adaptive.retryWithErrorMode(UnionMode[String])(
-  RetryConfig(Schedule.Immediate(3), ResultPolicy.retryWhen(_ != "fatal error")))(unionOperation)
+adaptive.retryWithErrorMode(UnionMode[String])(RetryConfig[String, Int](
+  Schedule.immediate.maxRepeats(3), ResultPolicy.retryWhen(_ != "fatal error")))(
+    unionOperation)
 
 // consider "throttling error" not as a failure that should incur the retry penalty
-adaptive.retryWithErrorMode(UnionMode[String])(
-  RetryConfig(Schedule.Immediate(3), ResultPolicy.retryWhen(_ != "fatal error")),
+adaptive.retryWithErrorMode(UnionMode[String])(RetryConfig[String, Int](
+    Schedule.immediate.maxRepeats(3), ResultPolicy.retryWhen(_ != "fatal error")),
   shouldPayFailureCost = _.fold(_ != "throttling error", _ => true))(unionOperation)
 ```

--- a/doc/utils/scheduled.md
+++ b/doc/utils/scheduled.md
@@ -1,88 +1,32 @@
 # Scheduled
 
-The `scheduled` functions allow to run an operation according to a given schedule.
-It is preferred to use `repeat`, `retry`, or combination of both functions for most use cases, as they provide a more convenient DSL.
-In fact `retry` and `repeat` use `scheduled` internally.
+The `scheduled` functions allow to run an operation according to a given schedule. It is preferred to use `repeat`, 
+`retry`, or combination of both functions for most use cases, as they provide a more convenient DSL. In fact `retry`
+and `repeat` use `scheduled` internally.
 
 ## Operation definition
 
-Similarly to the `retry` and `repeat` APIs, the `operation` can be defined: 
+Similarly to the `retry` and `repeat` APIs, the `operation` can be provided:
+
 * directly using a by-name parameter, i.e. `f: => T`
 * using a by-name `Either[E, T]`
-* or using an arbitrary [error mode](../basics/error-handling.md), accepting the computation in an `F` context: `f: => F[T]`.
+* or using an arbitrary [error mode](../basics/error-handling.md), accepting the computation in an `F` 
+  context: `f: => F[T]`.
 
 ## Configuration
 
 The `scheduled` config consists of:
+
 - a `Schedule`, which indicates how many times the `operation` should be run, provides a duration based on which
   a sleep is calculated and provides an initial delay if configured.
 - a `SleepMode`, which determines how the sleep between subsequent operations should be calculated:
   - `Interval` - default for `repeat` operations, where the sleep is calculated as the duration provided by schedule 
     minus the duration of the last operation (can be negative, in which case the next operation occurs immediately).
   - `Delay` - default for `retry` operations, where the sleep is just the duration provided by schedule.
-- `afterAttempt` - a callback function that is invoked after each operation and determines if the scheduler loop should continue. Used for `onRetry`, `shouldContinueOnError`, `shouldContinueOnResult` and adaptive retries in `retry` API. Defaults to always continuing.
+- `afterAttempt` - a callback function that is invoked after each operation and determines if the scheduler loop 
+  should continue. Used for `onRetry`, `shouldContinueOnError`, `shouldContinueOnResult` and adaptive retries in 
+  `retry` API. Defaults to always continuing.
 
 ## Schedule
 
-### Finite schedules
-
-Finite schedules have a common `maxRepeats: Int` parameter, which determines how many times the `operation` can be
-repeated. This means that the operation could be executed at most `maxRepeats + 1` times.
-
-### Infinite schedules
-
-Each finite schedule has an infinite variant, whose settings are similar to those of the respective finite schedule, but
-without the `maxRepeats` setting. Using the infinite variant can lead to a possibly infinite number of retries (unless
-the `operation` starts to succeed again at some point). The infinite schedules are created by calling `.forever` on the
-companion object of the respective finite schedule (see examples below).
-
-### Schedule types
-
-The supported schedules (specifically - their finite variants) are:
-
-- `InitialDelay(delay: FiniteDuration)` - used to configure the initial delay (the delay before the first invocation of 
-  the operation, used in `repeat` API only).
-- `Immediate(maxRepeats: Int)` - repeats up to `maxRepeats` times, always returning duration equal to 0.
-- `Fixed(maxRepeats: Int, duration: FiniteDuration)` - repeats up to `maxRepeats` times, always returning 
-  the provided `duration`.
-- `Backoff(maxRepeats: Int, firstDuration: FiniteDuration, maxDuration: FiniteDuration, jitter: Jitter)` - repeats up
-  to `maxRepeats` times, returning `firstDuration` after the first invocation, increasing the duration between subsequent
-  invocations exponentially (with base `2`) up to an optional `maxDuration` (default: 1 minute).
-
-  Optionally, a random factor (jitter) can be used when calculating the delay before the next invocation. The purpose of
-  jitter is to avoid clustering of subsequent invocations, i.e. to reduce the number of clients calling a service exactly at
-  the same time, which can result in subsequent failures, contrary to what you would expect from retrying. By
-  introducing randomness to the delays, the retries become more evenly distributed over time.
-
-  See
-  the [AWS Architecture Blog article on backoff and jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)
-  for a more in-depth explanation.
-
-  The following jitter strategies are available (defined in the `Jitter` enum):
-  - `None` - the default one, when no randomness is added, i.e. a pure exponential backoff is used,
-  - `Full` - picks a random value between `0` and the exponential backoff calculated for the current attempt,
-  - `Equal` - similar to `Full`, but prevents very short delays by always using a half of the original backoff and
-    adding a random value between `0` and the other half,
-  - `Decorrelated` - uses the delay from the previous attempt (`lastDelay`) and picks a random value between
-    the `initalAttempt` and `3 * lastDelay`.
-
-## Combining schedules
-
-It is possible to combine schedules using `.andThen` method. The left side schedule must be a `Finite`
-or `InitialDelay` schedule and the right side can be any schedule.
-
-### Examples
-
-```scala mdoc:compile-only
-import ox.scheduling.Schedule
-import scala.concurrent.duration.*
-
-// schedule 3 times immediately and then 3 times with fixed duration
-Schedule.Immediate(3).andThen(Schedule.Fixed(3, 100.millis))
-
-// schedule 3 times immediately and then forever with fixed duration
-Schedule.Immediate(3).andThen(Schedule.Fixed.forever(100.millis))
-
-// schedule with an initial delay and then forever with fixed duration
-Schedule.InitialDelay(100.millis).andThen(Schedule.Fixed.forever(100.millis))
-```
+See the [retry](retries.md) documentation for an overview of the available ways to create and modify a `Schedule`.


### PR DESCRIPTION
The  new `Schedule` class allows for compositional definitions of schedules, and follows the design outlined by @miciek  in https://www.youtube.com/watch?v=RWvTziDfFUQ.