### PR TITLE
Fix AdaptiveRetry stopping on Left when shouldPayFailureCost returns false

### DIFF
--- a/core/src/test/scala/ox/resilience/ImmediateRetryTest.scala
+++ b/core/src/test/scala/ox/resilience/ImmediateRetryTest.scala
@@ -210,4 +210,21 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
     result.value shouldBe message
     counter shouldBe 6
 
+  it should "not pay exceptionCost if Left error is going to be retried and shouldPayPenaltyCost returns false" in:
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f: Either[String, Int] =
+      counter += 1
+      Left(errorMessage)
+
+    val adaptive = AdaptiveRetry(TokenBucket(2), 1, 1)
+    // when
+    val result = adaptive.retryEither(Schedule.immediate.maxRetries(5), (_: Either[String, Int]) => false)(f)
+
+    // then
+    result.left.value shouldBe errorMessage
+    counter shouldBe 6
+
 end ImmediateRetryTest


### PR DESCRIPTION
Fixes #442.

When AdaptiveRetry encounters a Left error and shouldPayFailureCost returns false, retrying should continue. Currently, the retry stops in this scenario.

This commit adds a failing test that demonstrates the expected behavior: retries should continue for the configured schedule even when the cost is not paid (shouldPayFailureCost returns false).

Closes softwaremill/ox#442.