### PR TITLE
Add test for AdaptiveRetry free retries when shouldPayFailureCost is false

### DIFF
--- a/core/src/test/scala/ox/resilience/AdaptiveRetryTest.scala
+++ b/core/src/test/scala/ox/resilience/AdaptiveRetryTest.scala
@@ -1,0 +1,32 @@
+package ox.resilience
+
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.scheduling.Schedule
+
+class AdaptiveRetryTest extends AnyFlatSpec with EitherValues with Matchers:
+
+  behavior of "AdaptiveRetry"
+
+  it should "not pay failureCost if result E is going to be retried and shouldPayFailureCost returns false" in:
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f: Either[String, Int] =
+      counter += 1
+      Left(errorMessage)
+
+    // Bucket smaller than the number of attempts: if the cost were paid, we'd stop early.
+    val adaptive = AdaptiveRetry(TokenBucket(2), 1, 1)
+
+    // when
+    val result = adaptive.retryEither(Schedule.immediate.maxRetries(5), _ => false)(f)
+
+    // then
+    result.left.value shouldBe errorMessage
+    // 1 initial + 5 retries, all for free since shouldPayFailureCost returns false
+    counter shouldBe 6
+
+end AdaptiveRetryTest


### PR DESCRIPTION
Reproduces issue #442: AdaptiveRetry incorrectly stops retrying on Left when shouldPayFailureCost returns false. 

The test verifies that when shouldPayFailureCost is false, retry attempts should not consume from the token bucket. Currently, all 6 attempts (1 initial + 5 retries) are expected to succeed despite a token bucket with only 2 tokens, since no cost should be paid.

The fix implementation will follow.

Closes softwaremill/ox#442.