### PR TITLE
Add failing test: Fix AdaptiveRetry stopping on Left when shouldPayFailureCost is false

### DIFF
--- a/core/src/test/scala/ox/resilience/ImmediateRetryTest.scala
+++ b/core/src/test/scala/ox/resilience/ImmediateRetryTest.scala
@@ -210,4 +210,22 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
     result.value shouldBe message
     counter shouldBe 6
 
+  it should "not pay failureCost if result E (Left) is going to be retried and shouldPayFailureCost returns false" in:
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Left(errorMessage)
+
+    val adaptive = AdaptiveRetry(TokenBucket(2), 1, 1)
+    // when
+    val result = adaptive.retryEither(Schedule.immediate.maxRetries(5), _ => false)(f)
+
+    // then
+    result.left.value shouldBe errorMessage
+    // All attempts are made for free (1 initial + 5 retries); the bucket is never touched
+    counter shouldBe 6
+
 end ImmediateRetryTest


### PR DESCRIPTION
When AdaptiveRetry encounters a Left (error) result and shouldPayFailureCost returns false, it should still retry without consuming tokens from the bucket. Currently, retries stop prematurely in this case.

This test verifies that all retry attempts complete even when the failure cost is not paid, ensuring the bucket constraint doesn't prevent retries when explicitly configured not to charge for them.

Related to softwaremill/ox#442.

Closes softwaremill/ox#442.