### PR TITLE
Fix AdaptiveRetry to retry retriable Left errors when shouldPayFailureCost is false

### DIFF
--- a/core/src/main/scala/ox/resilience/AdaptiveRetry.scala
+++ b/core/src/main/scala/ox/resilience/AdaptiveRetry.scala
@@ -76,7 +76,7 @@ case class AdaptiveRetry(
           // If we want to retry we try to acquire tokens from bucket
           if config.resultPolicy.isWorthRetrying(value) then
             if shouldPayFailureCost(Left(value)) then ScheduleStop(!tokenBucket.tryAcquire(failureCost))
-            else ScheduleStop.Yes
+            else ScheduleStop.No
           else ScheduleStop.Yes
         case Right(value) =>
           // If we are successful, we release tokens to bucket and end schedule

--- a/core/src/test/scala/ox/resilience/ImmediateRetryTest.scala
+++ b/core/src/test/scala/ox/resilience/ImmediateRetryTest.scala
@@ -210,4 +210,22 @@ class ImmediateRetryTest extends AnyFlatSpec with EitherValues with TryValues wi
     result.value shouldBe message
     counter shouldBe 6
 
+  it should "not pay failureCost if result E is going to be retried and shouldPayFailureCost returns false" in:
+    // given
+    var counter = 0
+    val errorMessage = "boom"
+
+    def f =
+      counter += 1
+      Left(errorMessage)
+
+    val adaptive = AdaptiveRetry(TokenBucket(2), 1, 1)
+    // when
+    val result = adaptive.retryEither(Schedule.immediate.maxRetries(5), _ => false)(f)
+
+    // then
+    result.left.value shouldBe errorMessage
+    // all attempts are made for free, without paying the failure cost: one initial + five retries
+    counter shouldBe 6
+
 end ImmediateRetryTest


### PR DESCRIPTION
When `shouldPayFailureCost` returns false for a retriable Left error, AdaptiveRetry was incorrectly stopping retries instead of continuing them. This meant that errors configured to not incur a failure cost would halt prematurely rather than retrying for free.

The fix changes the logic to return `ScheduleStop.No` when `shouldPayFailureCost` is false, ensuring that retriable errors continue to be retried without consuming tokens from the bucket.

Added a test case verifying that all retry attempts execute when `shouldPayFailureCost` returns false, confirming 1 initial attempt plus 5 configured retries are all performed.

Fixes #442.

Closes softwaremill/ox#442.