### PR TITLE
Make Flow.range support descending ranges with negative step

### DIFF
--- a/core/src/main/scala/ox/flow/FlowCompanionOps.scala
+++ b/core/src/main/scala/ox/flow/FlowCompanionOps.scala
@@ -96,6 +96,7 @@ trait FlowCompanionOps:
         emit(t)
         t = t + step
         if step >= 0 then t <= to else t >= to
+  end range
 
   /** Creates a flow which emits the first element of tuples returned by repeated applications of `f`. The `initial` state is used for the
     * first application, and then the state is updated with the second element of the tuple. Emission stops when `f` returns `None`,

--- a/core/src/main/scala/ox/flow/FlowCompanionOps.scala
+++ b/core/src/main/scala/ox/flow/FlowCompanionOps.scala
@@ -85,13 +85,17 @@ trait FlowCompanionOps:
       emit(t)
       t = f(t)
 
-  /** Creates a flow which emits a range of numbers, from `from`, to `to` (inclusive), stepped by `step`. */
-  def range(from: Int, to: Int, step: Int): Flow[Int] = usingEmitInline: emit =>
-    var t = from
-    repeatWhile:
-      emit(t)
-      t = t + step
-      t <= to
+  /** Creates a flow which emits a range of numbers, from `from`, to `to` (inclusive), stepped by `step`. A negative `step` produces a
+    * descending range, e.g. `range(5, 1, -1)` emits `5, 4, 3, 2, 1`. The `step` must be non-zero.
+    */
+  def range(from: Int, to: Int, step: Int): Flow[Int] =
+    require(step != 0, "step must be non-zero")
+    usingEmitInline: emit =>
+      var t = from
+      repeatWhile:
+        emit(t)
+        t = t + step
+        if step >= 0 then t <= to else t >= to
 
   /** Creates a flow which emits the first element of tuples returned by repeated applications of `f`. The `initial` state is used for the
     * first application, and then the state is updated with the second element of the tuple. Emission stops when `f` returns `None`,

--- a/core/src/test/scala/ox/flow/FlowOpsFactoryMethodsTest.scala
+++ b/core/src/test/scala/ox/flow/FlowOpsFactoryMethodsTest.scala
@@ -25,4 +25,8 @@ class FlowOpsFactoryMethodsTest extends AnyFlatSpec with Matchers:
     Flow.range(1, 5, 1).runToList() shouldBe List(1, 2, 3, 4, 5)
     Flow.range(1, 5, 2).runToList() shouldBe List(1, 3, 5)
     Flow.range(1, 11, 3).runToList() shouldBe List(1, 4, 7, 10)
+
+  it should "produce a descending range with a negative step" in:
+    Flow.range(5, 1, -1).runToList() shouldBe List(5, 4, 3, 2, 1)
+    Flow.range(10, 0, -2).runToList() shouldBe List(10, 8, 6, 4, 2, 0)
 end FlowOpsFactoryMethodsTest


### PR DESCRIPTION
Fixes #439 — Flow.range with a negative step was only emitting the first element due to incorrect termination logic.

The original implementation used a fixed termination condition (`t <= to`) that didn't account for negative steps. With a negative step, this condition would cause the loop to terminate prematurely.

The fix updates the range method to:
- Require non-zero step values
- Use conditional termination logic: `t <= to` for positive steps, `t >= to` for negative steps
- Document the descending range behavior with examples

Test cases for descending ranges have been added to verify the fix works correctly.

Closes softwaremill/ox#439.